### PR TITLE
Allow owner.limit to be set via redis (aka "boosts")

### DIFF
--- a/lib/travis/scheduler.rb
+++ b/lib/travis/scheduler.rb
@@ -1,5 +1,6 @@
 $stdout.sync = true
 
+require 'redis'
 require 'travis/support'
 require 'travis/support/logging'
 require 'travis/support/logger'
@@ -19,6 +20,10 @@ module Travis
 
       def logger=(logger)
         @logger = Logger.configure(logger)
+      end
+
+      def redis
+        @redis ||= Redis.connect(config[:redis])
       end
 
       def uuid=(uuid)

--- a/lib/travis/scheduler/services/limit/configurable.rb
+++ b/lib/travis/scheduler/services/limit/configurable.rb
@@ -67,7 +67,8 @@ module Travis
           end
 
           def max_jobs
-            config[:by_owner][owner.login] ||
+            max_boost_jobs(owner.login) ||
+              config[:by_owner][owner.login] ||
               max_jobs_from_container_account ||
               max_jobs_based_on_plan(owner) ||
               config[:default]
@@ -90,9 +91,10 @@ module Travis
           end
 
           def max_jobs_from_container_account
-            if delegate
-              config[:by_owner][delegate.login] || max_jobs_based_on_plan(delegate)
-            end
+            return unless delegate
+            max_boost_jobs(delegate.login) ||
+              config[:by_owner][delegate.login] ||
+              max_jobs_based_on_plan(delegate)
           end
 
           def number_of_running_delegatees_jobs

--- a/lib/travis/scheduler/services/limit/default.rb
+++ b/lib/travis/scheduler/services/limit/default.rb
@@ -75,7 +75,15 @@ module Travis
             end
 
             def max_jobs
-              config[:by_owner][owner.login] || config[:default]
+              max_boost_jobs(owner.login) || config[:by_owner][owner.login] || config[:default]
+            end
+
+            def max_boost_jobs(login)
+              limit = Travis::Scheduler.redis.get("scheduler.owner.limit.#{login}").to_i
+              limit if limit > 0
+            rescue Redis::BaseError => e
+              Scheduler.logger.error([e.message] + e.backtrace)
+              nil
             end
 
             def unlimited?

--- a/spec/travis/scheduler/services/limit/default_spec.rb
+++ b/spec/travis/scheduler/services/limit/default_spec.rb
@@ -4,8 +4,9 @@ require 'travis/scheduler/services/limit/default'
 describe Travis::Scheduler::Services::Limit::Default do
   include Travis::Testing::Stubs
 
-  let(:jobs)  { 10.times.map { stub_test } }
+  let(:jobs)  { 12.times.map { stub_test } }
   let(:limit) { described_class.new(org, jobs) }
+  let(:redis) { Travis::Scheduler.redis }
 
   before do
     jobs.each do |job|
@@ -28,21 +29,33 @@ describe Travis::Scheduler::Services::Limit::Default do
     expect(limit.queueable).to eq(jobs[0, 1])
   end
 
-  it 'allows the first 8 jobs if the org is allowed 8 jobs' do
-    Travis.config.limit = { by_owner: { org.login => 8 } }
-    limit.stubs(running: 0)
-    expect(limit.queueable).to eq(jobs[0, 8])
+  describe 'boost' do
+    before { redis.set("scheduler.owner.limit.#{org.login}", 10) }
+    after  { redis.del("scheduler.owner.limit.#{org.login}") }
+
+    it 'allows the first 10 jobs if the org has a boost of 10 jobs' do
+      limit.stubs(running: 0)
+      expect(limit.queueable).to eq(jobs[0, 10])
+    end
   end
 
-  it 'allows all jobs if the limit is set to -1' do
-    Travis.config.limit = { by_owner: { org.login => -1 } }
-    limit.stubs(running: 10)
-    expect(limit.queueable).to eq(jobs)
+  describe 'config.limit' do
+    it 'allows the first 8 jobs if the org is allowed 8 jobs' do
+      Travis.config.limit = { by_owner: { org.login => 8 } }
+      limit.stubs(running: 0)
+      expect(limit.queueable).to eq(jobs[0, 8])
+    end
+
+    it 'allows all jobs if the limit is set to -1' do
+      Travis.config.limit = { by_owner: { org.login => -1 } }
+      limit.stubs(running: 12)
+      expect(limit.queueable).to eq(jobs)
+    end
   end
 
   it 'gives a readable report' do
     limit.stubs(running: 3)
-    expect(limit.report).to eq({ total: 10, running: 3, max: 5, queueable: 2 })
+    expect(limit.report).to eq({ total: 12, running: 3, max: 5, queueable: 2 })
   end
 
   describe "limit per repository" do
@@ -75,7 +88,7 @@ describe Travis::Scheduler::Services::Limit::Default do
 
     it "doesn't allow for a repository maximum higher than the total maximum" do
       jobs.each do |job|
-        job.repository.stubs(:settings).returns OpenStruct.new({:restricts_number_of_builds? => true, :maximum_number_of_builds => 10})
+        job.repository.stubs(:settings).returns OpenStruct.new({:restricts_number_of_builds? => true, :maximum_number_of_builds => 12})
         expect(limit.queueable.size).to eq(5)
       end
     end


### PR DESCRIPTION
If threre's a Redis key `scheduler.owner.limit.[owner_login]` set to a value > 0, then this will take precedence over all other limits/values (so it should not be set to a value lower than the limit currently paid for via the subscription).

E.g. if a customer is on a 2-builds plan, and you want to give them 5 extra, then set it to 7.