### PR TITLE
Add `vm_type` to the worker payload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm: 2.1.5
 
 services:
   - redis
+  - rabbitmq
 
 addons:
   postgresql: 9.3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Travis Scheduler [![Build Status](https://travis-ci.org/travis-ci/travis-scheduler.svg?branch=master)](https://travis-ci.org/travis-ci/travis-scheduler)
 
+*Keeper of the limits*
+
 Scheduler is the application that, in the life-cycle of accepting,
 evaluating, and executing a build request, sits in the third position.
 

--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -4,7 +4,7 @@ module Travis
   module Scheduler
     class Config < Travis::Config
       define  amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
-              database:      { adapter: 'postgresql', database: "travis_development", encoding: 'unicode', min_messages: 'warning' },
+              database:      { adapter: 'postgresql', database: "travis_#{env}", encoding: 'unicode', min_messages: 'warning' },
               encryption:    { },
               github:        { },
               interval:      2,

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -1,3 +1,5 @@
+require 'travis/scheduler/support/features'
+
 module Travis
   module Scheduler
     module Payloads
@@ -28,6 +30,7 @@ module Travis
         def data
           {
             'type' => 'test',
+            'vm_type' => vm_type,
             # TODO legacy. remove this once workers respond to a 'job' key
             'build' => job_data,
             'job' => job_data,
@@ -80,6 +83,10 @@ module Travis
             'last_build_state' => repository.last_build_state.to_s,
             'description' => repository.description
           }
+        end
+
+        def vm_type
+          Support::Features.active?(:premium_vms, repository) ? 'premium' : 'default'
         end
 
         def ssh_key

--- a/lib/travis/scheduler/schedule.rb
+++ b/lib/travis/scheduler/schedule.rb
@@ -18,6 +18,7 @@ module Travis
         Travis::Exceptions::Reporter.start
         Travis::Metrics.setup
         Support::Sidekiq.setup(config)
+        Support::Features.setup(config)
 
         declare_exchanges_and_queues
       end

--- a/lib/travis/scheduler/support/features.rb
+++ b/lib/travis/scheduler/support/features.rb
@@ -1,0 +1,154 @@
+require 'redis'
+require 'rollout'
+require 'active_support/deprecation'
+require 'active_support/core_ext/module'
+require 'travis/scheduler/support/redis_pool'
+
+module Travis
+  module Scheduler
+    module Support
+      # Travis::Features contains methods to handle feature flags.
+      module Features
+        class << self
+          methods = (Rollout.public_instance_methods(false) - [:active?, "active?"]) << {:to => :rollout}
+          delegate(*methods)
+
+          def setup(config)
+            @redis = RedisPool.new(config[:redis].to_h)
+          end
+        end
+
+        attr_reader :redis
+
+        def rollout
+          @rollout ||= ::Rollout.new(redis)
+        end
+
+        # Returns whether a given feature is enabled either globally or for a given
+        # repository.
+        #
+        # By default, this will return false.
+        def active?(feature, repository)
+          feature_active?(feature) or
+            (rollout.active?(feature, repository.owner) or
+              repository_active?(feature, repository))
+        end
+
+        def activate_repository(feature, repository)
+          redis.sadd(repository_key(feature), repository_id(repository))
+        end
+
+        def deactivate_repository(feature, repository)
+          redis.srem(repository_key(feature), repository_id(repository))
+        end
+
+        # Return whether a given feature is enabled for a repository.
+        #
+        # By default, this will return false.
+        def repository_active?(feature, repository)
+          redis.sismember(repository_key(feature), repository_id(repository))
+        end
+
+        # Return whether a given feature is enabled for a user.
+        #
+        # By default, this will return false.
+        def user_active?(feature, user)
+          rollout.active?(feature, user)
+        end
+
+        def activate_all(feature)
+          redis.del(disabled_key(feature))
+        end
+
+        # Return whether a feature is enabled globally.
+        #
+        # By default, this will return false.
+        def feature_active?(feature)
+          enabled_for_all?(feature) and !feature_inactive?(feature)
+        end
+
+        # Return whether a feature has been disabled.
+        #
+        # This is similar to feature_deactivated?, but with the opposite default.
+        #
+        # By default this will return true (ie. disabled).
+        def feature_inactive?(feature)
+          redis.get(disabled_key(feature)) != "1"
+        end
+
+        # Return whether a feature has been disabled.
+        #
+        # This is similar to feature_inactive?, but with the opposite default.
+        #
+        # By default this will return false (ie not disabled).
+        def feature_deactivated?(feature)
+          redis.get(disabled_key(feature)) == '0'
+        end
+
+        def deactivate_all(feature)
+          redis.set(disabled_key(feature), 0)
+        end
+
+        # Return whether a feature has been enabled globally.
+        #
+        # By default this will return false.
+        def enabled_for_all?(feature)
+          redis.get(enabled_for_all_key(feature)) == '1'
+        end
+
+        def enable_for_all(feature)
+          redis.set(enabled_for_all_key(feature), 1)
+        end
+
+        def disable_for_all(feature)
+          redis.set(enabled_for_all_key(feature), 0)
+        end
+
+        def activate_owner(feature, owner)
+          redis.sadd(owner_key(feature, owner), owner.id)
+        end
+
+        def deactivate_owner(feature, owner)
+          redis.srem(owner_key(feature, owner), owner.id)
+        end
+
+        # Return whether a feature has been enabled for a user.
+        #
+        # By default, this return false.
+        def owner_active?(feature, owner)
+          redis.sismember(owner_key(feature, owner), owner.id)
+        end
+
+        extend self
+
+        private
+
+        def key(name)
+          "feature:#{name}"
+        end
+
+        def owner_key(feature, owner)
+          # suffix = owner.class.table_name
+          suffix = owner.class.name.tableize
+          "#{key(feature)}:#{suffix}"
+        end
+
+        def repository_key(feature)
+          "#{key(feature)}:repositories"
+        end
+
+        def disabled_key(feature)
+          "#{key(feature)}:disabled"
+        end
+
+        def enabled_for_all_key(feature)
+          "#{key(feature)}:disabled"
+        end
+
+        def repository_id(repository)
+          repository.respond_to?(:id) ? repository.id : repository.to_i
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/scheduler/support/redis_pool.rb
+++ b/lib/travis/scheduler/support/redis_pool.rb
@@ -1,0 +1,31 @@
+require 'connection_pool'
+require 'redis'
+
+module Travis
+  module Scheduler
+    module Support
+      class RedisPool
+        attr_reader :pool
+
+        def initialize(options = {})
+          pool_options = options.delete(:pool) || {}
+          pool_options[:size] ||= 10
+          pool_options[:timeout] ||= 10
+          @pool = ConnectionPool.new(pool_options) do
+            ::Redis.new(options)
+          end
+        end
+
+        def method_missing(name, *args, &block)
+          @pool.with do |redis|
+            if redis.respond_to?(name)
+              redis.send(name, *args, &block)
+            else
+              super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,20 +1,19 @@
 ENV['RAILS_ENV'] ||= 'test'
 
 require 'simplecov' if ENV['RAILS_ENV'] == 'test' && ENV['COVERAGE']
-
 require 'travis/scheduler'
 require 'travis/support'
-
 require 'stringio'
 require 'mocha'
 require 'factory_girl'
 
+Travis::Scheduler::Schedule.new.setup
+Travis::Scheduler.config.encryption.key = 'secret' * 10
+Travis.logger = Logger.new(StringIO.new)
+
 require 'support/active_record'
 require 'support/factories'
 require 'support/stubs'
-
-Travis.logger = Logger.new(StringIO.new)
-Travis::Scheduler.config.encryption.key = 'secret' * 10
 
 include Mocha::API
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -5,15 +5,7 @@ require 'database_cleaner'
 
 FileUtils.mkdir_p('log')
 
-# TODO: why not make this use Travis::Database.connect ?
-config = Travis.config.database.to_h
-config.merge!('adapter' => 'jdbcpostgresql', 'username' => ENV['USER']) if RUBY_PLATFORM == 'java'
-config['database'] = "travis_test"
-
-ActiveRecord::Base.default_timezone = :utc
 ActiveRecord::Base.logger = Logger.new('log/test.db.log')
-ActiveRecord::Base.configurations = { 'test' => config }
-ActiveRecord::Base.establish_connection('test')
 
 ActiveRecord::Base.connection.drop_table "subscriptions" rescue nil
 ActiveRecord::Base.connection.create_table "subscriptions", :force => true do |t|

--- a/spec/support/stubs.rb
+++ b/spec/support/stubs.rb
@@ -15,7 +15,8 @@ module Travis
             let(:request)             { stub_request             }
             let(:commit)              { stub_commit              }
             let(:build)               { stub_build               }
-            let(:test)                { stub_test                }
+            let(:test)                { stub_job                 }
+            let(:job)                 { stub_job                 }
             let(:log)                 { stub_log                 }
             let(:annotation)          { stub_annotation          }
             let(:annotation_provider) { stub_annotation_provider }
@@ -138,7 +139,7 @@ module Travis
           request: request,
           commit_id: commit.id,
           commit: commit,
-          matrix: attributes[:matrix] || [stub_test(id: 1, number: '2.1'), stub_test(id: 2, number: '2.2')],
+          matrix: attributes[:matrix] || [stub_job(id: 1, number: '2.1'), stub_job(id: 2, number: '2.2')],
           matrix_ids: [1, 2],
           cached_matrix_ids: [1, 2],
           number: 2,
@@ -162,7 +163,7 @@ module Travis
         )
       end
 
-      def stub_test(attributes = {})
+      def stub_job(attributes = {})
         log = self.log
         annotation = stub_annotation(job_id: 1)
         test = Stubs.stub 'test', attributes.reverse_merge(
@@ -220,7 +221,7 @@ module Travis
         Stubs.stub 'annotation', attributes.reverse_merge(
           class: Stubs.stub('class', name: 'Annotation'),
           id: 1,
-          job_id: attributes[:job_id] || test.id, # Needed to break the infinite loop in stub_test
+          job_id: attributes[:job_id] || test.id, # Needed to break the infinite loop in stub_job
           annotation_provider_id: annotation_provider.id,
           annotation_provider: annotation_provider,
           description: "The job passed.",
@@ -330,14 +331,6 @@ module Travis
       def stub_email(attributes = {})
         Stubs.stub 'email', attributes.reverse_merge(
           email: 'email'
-        )
-      end
-
-      def stub_job(attributes = {})
-        Stubs.stub 'job', attributes.reverse_merge(
-          repository: stub_repository,
-          id: '42.1',
-          enqueue: true
         )
       end
     end

--- a/spec/travis/scheduler/helpers/live_spec.rb
+++ b/spec/travis/scheduler/helpers/live_spec.rb
@@ -3,7 +3,7 @@ require 'travis/scheduler/helpers/live'
 describe Travis::Scheduler::Helpers::Live::Notifier do
   include Travis::Testing::Stubs
 
-  let(:job) { stub_test(state: :queued) }
+  let(:job) { stub_job(state: :queued) }
   subject   { described_class.new(job) }
 
   describe 'enqueues a sidekiq job to pusher_tasks' do

--- a/spec/travis/scheduler/services/limit/configurable_spec.rb
+++ b/spec/travis/scheduler/services/limit/configurable_spec.rb
@@ -4,7 +4,7 @@ require 'travis/scheduler/models/repository'
 describe Travis::Scheduler::Services::Limit::Configurable do
   include Travis::Testing::Stubs
 
-  let(:jobs)  { 10.times.map { |id| stub_test(id: id) } }
+  let(:jobs)  { 10.times.map { |id| stub_job(id: id) } }
   let(:limit) { described_class.new(organization, jobs) }
   let(:redis) { Travis::Scheduler.redis }
 

--- a/spec/travis/scheduler/services/limit/default_spec.rb
+++ b/spec/travis/scheduler/services/limit/default_spec.rb
@@ -4,7 +4,7 @@ require 'travis/scheduler/services/limit/default'
 describe Travis::Scheduler::Services::Limit::Default do
   include Travis::Testing::Stubs
 
-  let(:jobs)  { 12.times.map { stub_test } }
+  let(:jobs)  { 12.times.map { stub_job } }
   let(:limit) { described_class.new(org, jobs) }
   let(:redis) { Travis::Scheduler.redis }
 
@@ -67,22 +67,22 @@ describe Travis::Scheduler::Services::Limit::Default do
 
     it 'schedules the maximum number of builds for a single repository' do
       limit.stubs(running: 1)
-      limit.stubs(running_jobs: [OpenStruct.new(repository_id: test.repository_id)])
+      limit.stubs(running_jobs: [OpenStruct.new(repository_id: job.repository_id)])
       expect(limit.queueable.size).to eq(2)
     end
 
     it "schedules jobs for other repositories" do
-      test = stub_test(repository_id: 11111, repository: stub_repo)
-      test.repository.stubs(:settings).returns OpenStruct.new({:restricts_number_of_builds? => false})
+      job = stub_job(repository_id: 11111, repository: stub_repo)
+      job.repository.stubs(:settings).returns OpenStruct.new({:restricts_number_of_builds? => false})
       limit.stubs(running: 1)
-      limit.stubs(running_jobs: [OpenStruct.new(repository_id: test.repository_id)])
+      limit.stubs(running_jobs: [OpenStruct.new(repository_id: job.repository_id)])
       expect(limit.queueable.size).to eq(3)
     end
 
     it "doesn't fail for repositories with no running jobs and restriction enabled" do
-      test = stub_test(repository_id: 11111, repository: stub_repo)
+      job = stub_job(repository_id: 11111, repository: stub_repo)
       limit.stubs(running: 1)
-      limit.stubs(running_jobs: [OpenStruct.new(repository_id: test.repository_id)])
+      limit.stubs(running_jobs: [OpenStruct.new(repository_id: job.repository_id)])
       expect(limit.queueable.size).to eq(3)
     end
 


### PR DESCRIPTION
This adds a new key `vm_type` to the root of the worker payload, which

* defaults to "default" and
* will be "premium" if the feature flag `premium_vms` is set for either
  the repository or its owner

This also duplicates the classes `Features` and `RedisPool` for the time
being and cleans up a few things about test setup and stub namings.

Implements travis-pro/team-blue#327