### PR TITLE
Add job.debug_otions to payload

### DIFF
--- a/lib/travis/scheduler/models/job.rb
+++ b/lib/travis/scheduler/models/job.rb
@@ -37,6 +37,7 @@ class Job < ActiveRecord::Base
   belongs_to :owner, polymorphic: true
 
   serialize :config
+  serialize :debug_options
   delegate :secure_env?, :full_addons?, to: :source
 
   def ssh_key

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -63,7 +63,8 @@ module Travis
             'tag' => request.tag_name.present? ? request.tag_name : nil,
             'pull_request' => commit.pull_request? ? commit.pull_request_number : false,
             'state' => job.state.to_s,
-            'secure_env_enabled' => job.secure_env?
+            'secure_env_enabled' => job.secure_env?,
+            'debug_options' => job.debug_options
           }
           data
         end

--- a/spec/support/stubs.rb
+++ b/spec/support/stubs.rb
@@ -191,7 +191,10 @@ module Travis
           tags: 'tag-a,tag-b',
           log_content: log.content,
           ssh_key: nil,
-          secure_env?: true
+          secure_env?: true,
+          debug_options: {
+
+          }
         )
 
         source = stub_build(:matrix => [test])

--- a/spec/travis/scheduler/payloads/worker_spec.rb
+++ b/spec/travis/scheduler/payloads/worker_spec.rb
@@ -69,7 +69,8 @@ describe Travis::Scheduler::Payloads::Worker do
         'tag' => nil,
         'pull_request' => false,
         'state' => 'passed',
-        'secure_env_enabled' => true
+        'secure_env_enabled' => true,
+        'debug_options' => {}
       )
     end
 
@@ -86,7 +87,8 @@ describe Travis::Scheduler::Payloads::Worker do
         'tag' => nil,
         'pull_request' => false,
         'state' => 'passed',
-        'secure_env_enabled' => true
+        'secure_env_enabled' => true,
+        'debug_options' => {}
       )
     end
 
@@ -178,7 +180,8 @@ describe Travis::Scheduler::Payloads::Worker do
         'tag' => nil,
         'pull_request' => 180,
         'state' => 'passed',
-        'secure_env_enabled' => false
+        'secure_env_enabled' => false,
+        'debug_options' => {}
       )
     end
 
@@ -195,7 +198,9 @@ describe Travis::Scheduler::Payloads::Worker do
         'tag' => nil,
         'pull_request' => 180,
         'state' => 'passed',
-        'secure_env_enabled' => false
+        'secure_env_enabled' => false,
+        'debug_options' => {}
+
       )
     end
 

--- a/spec/travis/scheduler/payloads/worker_spec.rb
+++ b/spec/travis/scheduler/payloads/worker_spec.rb
@@ -136,6 +136,17 @@ describe Travis::Scheduler::Payloads::Worker do
     end
   end
 
+  describe 'for a debug build request' do
+    let(:debug_options) { {"stage"=>"before_install", "previous_state"=>"failed", "created_by"=>"svenfuchs", "quiet"=>"false"} }
+    before :each do
+      job.stubs(:debug_options).returns(debug_options)
+    end
+
+    it 'contains expected data' do
+      expect(data['job']['debug_options']).to eq(debug_options)
+    end
+  end
+
   describe 'for a pull request' do
     before :each do
       commit.stubs(:pull_request?).returns(true)


### PR DESCRIPTION
https://github.com/travis-ci/travis-migrations/pull/7 adds
debug_otions to Jobs table, and we want to put it on the payload
so that travis-build can see it.