### PR TITLE
Add `cache_settings` to the scheduler payload

### DIFF
--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -17,7 +17,8 @@ module Travis
               redis:         { url: 'redis://localhost:6379' },
               sentry:        { },
               sidekiq:       { namespace: 'sidekiq', pool_size: 3 },
-              ssl:           { }
+              ssl:           { },
+              cache_settings: { }
     end
   end
 end

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -40,7 +40,12 @@ module Travis
             'queue' => job.queue,
             'ssh_key' => ssh_key,
             'env_vars' => env_vars,
-            'timeouts' => timeouts
+            'timeouts' => timeouts,
+            'cache_settings' => {
+              'bucket' => 'secret_bucket',
+              'access_key_id' => ENV['SCHEDULER_ACCESS_KEY_ID'],
+              'secret_access_key' => ENV['SCHEDULER_SECRET_ACCESS_KEY']
+            }
           }
         end
 

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -43,7 +43,7 @@ module Travis
             'timeouts' => timeouts,
           }
           if Travis.config.cache_settings.to_h.tap {|x| puts x}
-            data.merge!({ 'cache_settings' => Travis.config.cache_settings.to_h[job.queue.to_sym].tap {|x| puts "chosen: #{x}"} })
+            data.merge!({ 'cache_settings' => Travis.config.cache_settings.to_h[job.queue.to_sym.tap {|x| puts "key: #{x}"}].tap {|x| puts "chosen: #{x}"} })
           end
           data
         end

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -42,9 +42,13 @@ module Travis
             'env_vars' => env_vars,
             'timeouts' => timeouts,
           }
-          if Travis.config.cache_settings && queue_settings = Travis.config.cache_settings.to_h.fetch(job.queue.to_sym, nil)
-            data.merge!({ 'cache_settings' => queue_settings })
+
+          if Support::Features.active?(:cache_settings, repository)
+            if Travis.config.cache_settings && queue_settings = Travis.config.cache_settings.to_h.fetch(job.queue.to_sym, nil)
+              data.merge!({ 'cache_settings' => queue_settings })
+            end
           end
+
           data
         end
 

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -42,8 +42,8 @@ module Travis
             'env_vars' => env_vars,
             'timeouts' => timeouts,
           }
-          if Travis.config.cache_settings
-            data.merge!({ 'cache_settings' => Travis.config.cache_settings.to_h[job.queue.to_sym] })
+          if Travis.config.cache_settings && queue_settings = Travis.config.cache_settings.to_h.fetch(job.queue.to_sym, nil)
+            data.merge!({ 'cache_settings' => queue_settings })
           end
           data
         end

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -42,8 +42,8 @@ module Travis
             'env_vars' => env_vars,
             'timeouts' => timeouts,
           }
-          if Travis.config.cache_settings.to_h.tap {|x| puts x}
-            data.merge!({ 'cache_settings' => Travis.config.cache_settings.to_h[job.queue.to_sym.tap {|x| puts "key: #{x}"}].tap {|x| puts "chosen: #{x}"} })
+          if Travis.config.cache_settings
+            data.merge!({ 'cache_settings' => Travis.config.cache_settings.to_h[job.queue.to_sym] })
           end
           data
         end

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -28,7 +28,7 @@ module Travis
 
 
         def data
-          {
+          data = {
             'type' => 'test',
             'vm_type' => vm_type,
             # TODO legacy. remove this once workers respond to a 'job' key
@@ -41,12 +41,11 @@ module Travis
             'ssh_key' => ssh_key,
             'env_vars' => env_vars,
             'timeouts' => timeouts,
-            'cache_settings' => {
-              'bucket' => 'secret_bucket',
-              'access_key_id' => ENV['SCHEDULER_ACCESS_KEY_ID'],
-              'secret_access_key' => ENV['SCHEDULER_SECRET_ACCESS_KEY']
-            }
           }
+          if Travis.config.cache_settings.to_h.tap {|x| puts x}
+            data.merge!({ 'cache_settings' => Travis.config.cache_settings.to_h[job.queue.to_sym] })
+          end
+          data
         end
 
         def build_data

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -43,7 +43,7 @@ module Travis
             'timeouts' => timeouts,
           }
           if Travis.config.cache_settings.to_h.tap {|x| puts x}
-            data.merge!({ 'cache_settings' => Travis.config.cache_settings.to_h[job.queue.to_sym] })
+            data.merge!({ 'cache_settings' => Travis.config.cache_settings.to_h[job.queue.to_sym].tap {|x| puts "chosen: #{x}"} })
           end
           data
         end

--- a/spec/travis/scheduler/payloads/worker_spec.rb
+++ b/spec/travis/scheduler/payloads/worker_spec.rb
@@ -9,6 +9,13 @@ describe Travis::Scheduler::Payloads::Worker do
   let(:data) { described_class.new(job).data }
   let(:foo)  { Travis::Settings::EncryptedColumn.new(use_prefix: false).dump('bar') }
   let(:bar)  { Travis::Settings::EncryptedColumn.new(use_prefix: false).dump('baz') }
+  let(:cache_settings_linux) {
+    {
+      access_key_id:      'ACCESS_KEY_ID',
+      secret_access_key:  'SECRET_ACCESS_KEY',
+      bucket_name:        'cache_bucket'
+    }
+  }
 
   let(:settings) do
     Repository::Settings.load({
@@ -23,6 +30,9 @@ describe Travis::Scheduler::Payloads::Worker do
 
   before :each do
     Travis.config.encryption.key = 'secret' * 10
+    Travis.config.cache_settings = {
+      :'builds.linux' => cache_settings_linux
+    }
     job.repository.stubs(:settings).returns(settings)
   end
 
@@ -53,7 +63,8 @@ describe Travis::Scheduler::Payloads::Worker do
         'timeouts' => {
           'hard_limit' => 180 * 60, # worker handles timeouts in seconds
           'log_silence' => 20 * 60
-        }
+        },
+        'cache_settings' => cache_settings_linux
       )
     end
 
@@ -175,7 +186,8 @@ describe Travis::Scheduler::Payloads::Worker do
         'timeouts' => {
           'hard_limit' => 180 * 60, # worker handles timeouts in seconds
           'log_silence' => 20 * 60
-        }
+        },
+        'cache_settings' => cache_settings_linux
       )
     end
 

--- a/spec/travis/scheduler/payloads/worker_spec.rb
+++ b/spec/travis/scheduler/payloads/worker_spec.rb
@@ -40,6 +40,7 @@ describe Travis::Scheduler::Payloads::Worker do
     before :each do
       commit.stubs(:pull_request?).returns(false)
       commit.stubs(:ref).returns(nil)
+      Travis::Scheduler::Support::Features.activate_owner(:cache_settings, job.repository.owner)
     end
 
     it 'contains the expected data' do


### PR DESCRIPTION
`cache_settings` will be the preferred cache configuration to be used by `travis-build`. This allows the cache configuration to be modified without altering the worker configurations, which is often an invasive change.