### PR TITLE
enqueue_jobs: Add the option to redirect from one queue to another

### DIFF
--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -19,7 +19,8 @@ module Travis
               sidekiq:       { namespace: 'sidekiq', pool_size: 3 },
               lock:          { strategy: :redis, ttl: 150 },
               ssl:           { },
-              cache_settings: { }
+              cache_settings: { },
+              queue_redirections: { }
     end
   end
 end

--- a/lib/travis/scheduler/services/enqueue_jobs.rb
+++ b/lib/travis/scheduler/services/enqueue_jobs.rb
@@ -72,6 +72,8 @@ module Travis
 
           def enqueue(jobs)
             jobs.each do |job|
+              queue_redirect(job)
+
               Travis.logger.info("enqueueing slug=#{job.repository.slug} job_id=#{job.id}")
               Metriks.timer('enqueue.publish_job').time do
                 publish(job)
@@ -116,7 +118,14 @@ module Travis
               'nothing to enqueue.'
             end
           end
-      end
+
+          def queue_redirect(job)
+            if Travis::Scheduler.config.queue_redirections.key?(job.queue)
+              job.queue = Travis::Scheduler.config.queue_redirections[job.queue]
+              job.save
+            end
+          end
+        end
     end
   end
 end

--- a/lib/travis/scheduler/services/enqueue_jobs.rb
+++ b/lib/travis/scheduler/services/enqueue_jobs.rb
@@ -120,9 +120,8 @@ module Travis
           end
 
           def queue_redirect(job)
-            Travis.logger.info "Found job with job.queue #{job.queue}"
             if queue = Travis::Scheduler.config.queue_redirections[job.queue]
-              Travis.logger.info "Now job.queue is #{job.queue}. Redirecting to: #{queue}"
+              Travis.logger.info "Found job.queue: #{job.queue}. Redirecting to: #{queue}"
               job.queue = queue
               job.save!
             end

--- a/lib/travis/scheduler/services/enqueue_jobs.rb
+++ b/lib/travis/scheduler/services/enqueue_jobs.rb
@@ -120,9 +120,12 @@ module Travis
           end
 
           def queue_redirect(job)
+            Travis.logger.info "Found job with job.queue #{job.queue}"
             if Travis::Scheduler.config.queue_redirections.key?(job.queue)
+              Travis.logger.info "Now job.queue is #{job.queue}. Should be build.linux"
               job.queue = Travis::Scheduler.config.queue_redirections[job.queue]
               job.save
+              Travis.logger.info "Changed job.queue to #{job.queue}"
             end
           end
         end

--- a/lib/travis/scheduler/services/enqueue_jobs.rb
+++ b/lib/travis/scheduler/services/enqueue_jobs.rb
@@ -121,11 +121,10 @@ module Travis
 
           def queue_redirect(job)
             Travis.logger.info "Found job with job.queue #{job.queue}"
-            if Travis::Scheduler.config.queue_redirections.key?(job.queue)
-              Travis.logger.info "Now job.queue is #{job.queue}. Should be build.linux"
-              job.queue = Travis::Scheduler.config.queue_redirections[job.queue]
-              job.save
-              Travis.logger.info "Changed job.queue to #{job.queue}"
+            if queue = Travis::Scheduler.config.queue_redirections[job.queue]
+              Travis.logger.info "Now job.queue is #{job.queue}. Redirecting to: #{queue}"
+              job.queue = queue
+              job.save!
             end
           end
         end


### PR DESCRIPTION
I'm not quite sure how best to test this, or if this is even the best approach, but this should help us in moving jobs from one queue to another as we move between infrastructures.