### PR TITLE
Convert timeouts to integer before sending to worker

### DIFF
--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -130,7 +130,7 @@ module Travis
         end
 
         def timeout(type)
-          timeout = settings.send(:"timeout_#{type}")
+          timeout = Integer(settings.send(:"timeout_#{type}"))
           timeout = timeout * 60 if timeout # worker handles timeouts in seconds
           timeout
         end

--- a/spec/travis/scheduler/payloads/worker_spec.rb
+++ b/spec/travis/scheduler/payloads/worker_spec.rb
@@ -260,6 +260,23 @@ describe Travis::Scheduler::Payloads::Worker do
     end
   end
 
+  describe 'for a build with string timeouts' do
+    let(:settings) do
+      Repository::Settings.load({
+        'env_vars' => [
+          { 'name' => 'FOO', 'value' => foo },
+          { 'name' => 'BAR', 'value' => bar, 'public' => true }
+        ],
+        'timeout_hard_limit' => '180',
+        'timeout_log_silence' => '20'
+      })
+    end
+
+    it 'converts them to ints' do
+      expect(data['timeouts']).to eq({'hard_limit' => 180*60, 'log_silence' => 20*60})
+    end
+  end
+
   def json_format_time(time)
     time.strftime('%Y-%m-%dT%H:%M:%SZ')
   end


### PR DESCRIPTION
It's possible for the timeouts to be stored as strings in the database, and worker doesn't handle string timeouts very well (it'll just fail to parse the JSON, since it expects an integer, and throw away the message, causing the job never to run).

/cc @svenfuchs 