### PR TITLE
Merge changes made in travis-pro/master to travis-ci/master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'travis-lock',        github: 'travis-ci/travis-lock'
 gem 'travis-config',      '~> 1.0.6'
 gem 'travis-migrations',  github: 'travis-ci/travis-migrations'
 
+gem 'gh',                 github: 'travis-ci/gh'
+
 gem 'rake'
 gem 'activerecord',       '~> 3.2'
 gem 'dalli'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,18 @@ GIT
     coder (0.4.0)
 
 GIT
+  remote: git://github.com/travis-ci/gh.git
+  revision: 27e30fd01f6d5144d8d7d0c88db7875b95ed8939
+  specs:
+    gh (0.14.0)
+      addressable
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (>= 2.7)
+      net-http-pipeline
+
+GIT
   remote: git://github.com/travis-ci/travis-amqp.git
   revision: 3966b3651adfd1c544f53d49d5986ac16cd9c4bc
   specs:
@@ -76,6 +88,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    backports (3.6.8)
     builder (3.0.4)
     bunny (2.3.0)
       amq-protocol (>= 2.0.1)
@@ -135,6 +148,8 @@ GEM
     multi_json (1.11.2)
     multipart-post (2.0.0)
     nenv (0.3.0)
+    net-http-persistent (2.9.4)
+    net-http-pipeline (1.0.1)
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -218,6 +233,7 @@ DEPENDENCIES
   dalli
   database_cleaner (~> 1.5.1)
   factory_girl
+  gh!
   guard
   guard-rspec
   metriks-librato_metrics

--- a/lib/travis/scheduler/branch_validator.rb
+++ b/lib/travis/scheduler/branch_validator.rb
@@ -1,0 +1,88 @@
+require 'travis/scheduler/models/branch'
+
+module Travis
+  module Scheduler
+    class BranchValidator < Struct.new(:branch_name, :repository)
+      attr_reader :last_response_status, :last_error_message
+
+      def valid?
+        # return false immediately if the branch name doesn't look like a branch
+        return false unless valid_branch_name?
+
+        # if the branch exists in the DB, we can return true
+        return true if branch_exists_in_the_db?
+
+        # if branch doesn't exist, hit GitHub's API
+        return branch_exists_on_github?
+      end
+
+      def branch_exists_in_the_db?
+        Branch.where(repository_id: repository.id, name: branch_name).exists?
+      end
+
+      def branch_exists_on_github?
+        candidates = repository.users.where("github_oauth_token IS NOT NULL").
+                                      order("updated_at DESC")
+
+        return unless candidates.exists?
+
+        # we will check only first 3 most recently updated users
+        candidates[0..4].any? do |user|
+          begin
+            result = nil
+
+            GH.with(token: user.github_oauth_token) do
+              result = !!fetch_branch
+            end
+
+            result
+          rescue GH::TokenInvalid
+            # do nothing and just go to the next user
+          end
+        end
+      end
+
+      def fetch_branch
+        tries ||= 1
+        GH["/repos/#{repository.slug}/branches/#{URI.escape(branch_name)}"]
+      rescue GH::TokenInvalid
+        raise
+      rescue GH::Error => e
+        # we can just return false if it's a 404 or 403
+        if  e.info[:response_status] == 404 || e.info[:response_status] == 403
+          if e.info
+            @last_response_status = e.info[:response_status]
+            @last_error_message = e.message
+          end
+
+          return false
+        end
+
+        if tries >= 3
+          # if it's any other 4xx error we're probably doing something wrong,
+          # bubble the error up
+          if e.info[:response_status] >= 400 && e.info[:response_status] < 500
+            raise
+          end
+        else
+          tries += 1
+          retry
+        end
+      end
+
+      def valid_branch_name?
+        regexp = /
+        ^(?!\/)  # can't begin with a slash
+         (?!.*\/\.) # path component can't begin with a dot
+         (?!.*\.\.) # can't contain 2 dots
+         (?!.*\/\/) # can't include double slash
+         [^\040\177[[:space:]]~^:?*\[\\\{@]+ # allow everything other then these chars
+         (?<!\.lock) # can't end with .lock
+         (?<![\/.])$ # can't end with \/ or .
+        /x
+
+        branch_name =~ regexp
+      end
+    end
+  end
+end

--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -6,6 +6,7 @@ module Travis
       define  amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
               database:      { adapter: 'postgresql', database: "travis_#{env}", encoding: 'unicode', min_messages: 'warning' },
               encryption:    { },
+              enterprise:    false,
               github:        { },
               interval:      2,
               limit:         { strategy: 'default', default: 5, by_owner: {}, delegate: {} },
@@ -20,7 +21,8 @@ module Travis
               lock:          { strategy: :redis, ttl: 150 },
               ssl:           { },
               cache_settings: { },
-              queue_redirections: { }
+              queue_redirections: { },
+              oauth2:        { }
     end
   end
 end

--- a/lib/travis/scheduler/encrypted_column.rb
+++ b/lib/travis/scheduler/encrypted_column.rb
@@ -1,0 +1,105 @@
+require 'securerandom'
+require 'base64'
+
+class Travis::Scheduler::EncryptedColumn
+  attr_reader :disable, :options
+  alias disabled? disable
+
+  def initialize(options = {})
+    @options = options || {}
+    @disable = self.options[:disable]
+    @key = self.options[:key]
+  end
+
+  def enabled?
+    !disabled?
+  end
+
+  def load(data)
+    return nil unless data
+
+    data = data.to_s
+
+    decrypt?(data) ? decrypt(data) : data
+  end
+
+  def dump(data)
+    encrypt?(data) ? encrypt(data.to_s) : data
+  end
+
+  def key
+    @key || config.key
+  end
+
+  def iv
+    SecureRandom.hex(8)
+  end
+
+  def prefix
+    '--ENCR--'
+  end
+
+  def decrypt?(data)
+    data.present? && (!use_prefix? || prefix_used?(data))
+  end
+
+  def encrypt?(data)
+    data.present? && enabled?
+  end
+
+  def prefix_used?(data)
+    data[0..7] == prefix
+  end
+
+  def decrypt(data)
+    data = data[8..-1] if prefix_used?(data)
+
+    data = decode data
+
+    iv   = data[-16..-1]
+    data = data[0..-17]
+
+    aes = create_aes :decrypt, key.to_s, iv
+
+    aes.update(data) + aes.final
+  end
+
+  def encrypt(data)
+    iv = self.iv
+
+    aes = create_aes :encrypt, key.to_s, iv
+
+    encrypted = aes.update(data) + aes.final
+
+    encrypted = "#{encrypted}#{iv}"
+    encrypted = encode encrypted
+    encrypted = "#{prefix}#{encrypted}" if use_prefix?
+    encrypted
+  end
+
+  def use_prefix?
+    options.has_key?(:use_prefix) ? options[:use_prefix] : true
+  end
+
+  def create_aes(mode = :encrypt, key, iv)
+    aes = OpenSSL::Cipher::AES.new(256, :CBC)
+
+    aes.send(mode)
+    aes.key = key
+    aes.iv  = iv
+
+    aes
+  end
+
+  def config
+    Travis.config.encryption
+  end
+
+  def decode(str)
+    Base64.strict_decode64 str
+  end
+
+  def encode(str)
+    Base64.strict_encode64 str
+  end
+end

--- a/lib/travis/scheduler/github.rb
+++ b/lib/travis/scheduler/github.rb
@@ -1,0 +1,21 @@
+require 'gh'
+require 'core_ext/hash/compact'
+
+module Travis
+  module Scheduler
+    module Github
+      class << self
+        def setup
+          GH.set(
+            client_id:      Travis.config.oauth2.client_id,
+            client_secret:  Travis.config.oauth2.client_secret,
+            user_agent:     "Travis-CI/Travis-Scheduler GH/#{GH::VERSION}",
+            origin:         Travis.config.host,
+            api_url:        Travis.config.github.api_url,
+            ssl:            Travis.config.ssl.to_h.merge(Travis.config.github.ssl || {}).to_h.compact
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/scheduler/models/branch.rb
+++ b/lib/travis/scheduler/models/branch.rb
@@ -1,0 +1,4 @@
+require 'active_record'
+
+class Branch < ActiveRecord::Base
+end

--- a/lib/travis/scheduler/models/permission.rb
+++ b/lib/travis/scheduler/models/permission.rb
@@ -1,0 +1,6 @@
+require 'active_record'
+
+class Permission < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :repository
+end

--- a/lib/travis/scheduler/models/repository.rb
+++ b/lib/travis/scheduler/models/repository.rb
@@ -1,11 +1,15 @@
 require 'active_record'
 require 'travis/scheduler/models/organization'
+require 'travis/scheduler/models/permission'
 require 'travis/scheduler/models/ssl_key'
 require 'travis/scheduler/models/user'
 
 class Repository < ActiveRecord::Base
   belongs_to :owner, polymorphic: true
   has_one    :key, class_name: :SslKey
+
+  has_many :permissions
+  has_many :users, :through => :permissions
 
   def slug
     @slug ||= [owner_name, name].join('/')

--- a/lib/travis/scheduler/models/request.rb
+++ b/lib/travis/scheduler/models/request.rb
@@ -3,6 +3,8 @@ require 'travis/scheduler/models/commit'
 require 'travis/scheduler/models/organization'
 require 'travis/scheduler/models/repository'
 require 'travis/scheduler/models/user'
+require 'travis/scheduler/branch_validator'
+require 'gh'
 
 class Request < ActiveRecord::Base
   belongs_to :commit
@@ -32,13 +34,47 @@ class Request < ActiveRecord::Base
     payload && payload['ref'] && payload['ref'].scan(%r{refs/tags/(.*?)$}).flatten.first
   end
 
+  # this method is overly long, but please don't refactor it just to shorten it,
+  # I want it to be as clear as possible as any bug here can lead to security
+  # issues
   def same_repo_pull_request?
     payload = Hashr.new(self.payload)
-    head_repo = payload.pull_request.try(:head).try(:repo).try(:full_name)
-    base_repo = payload.pull_request.try(:base).try(:repo).try(:full_name)
-    !!(head_repo && base_repo && head_repo == base_repo)
+
+    pull_request = payload.pull_request
+    return false unless pull_request
+
+    head = pull_request.head
+    base = pull_request.base
+    return false if head.nil? or base.nil?
+
+    base_repo = base.repo.try(:full_name)
+    head_repo = head.repo.try(:full_name)
+    return false if base_repo.nil? or base_repo.nil?
+
+    sha = head.sha
+    ref = head.ref.to_s
+    return false if sha.nil? or ref.nil?
+
+    # it's not the same repo PR if repo names don't match
+    return false if head_repo != base_repo
+
+    # it may not be same repo PR if ref is a commit
+    return false if sha =~ /^#{Regexp.escape(ref)}/
+
+    validator = Travis::Scheduler::BranchValidator.new(ref, repository)
+    result = validator.valid?
+
+    unless result
+      Travis::Scheduler.logger.info "[request:#{id}] PR is not for the same repo slug=#{repository.slug} head_repo=#{head_repo} base_repo=#{base_repo} sha=#{sha} ref=#{ref} validator.valid_branch_name?=#{!!validator.valid_branch_name?} validator.branch_exists_in_the_db?=#{!!validator.branch_exists_in_the_db?} validator.branch_exists_on_github?=#{!!validator.branch_exists_on_github?} validator.last_response_status=#{validator.last_response_status.inspect} last_error_message=#{validator.last_error_message}"
+    end
+
+    result
   rescue => e
     Travis::Scheduler.logger.error "[request:#{id}] Couldn't determine whether pull request is from the same repository: #{e.message}"
     false
   end
+
+  private
+
+
 end

--- a/lib/travis/scheduler/models/user.rb
+++ b/lib/travis/scheduler/models/user.rb
@@ -1,8 +1,10 @@
 require 'active_record'
 require 'travis/scheduler/models/subscription'
+require 'travis/scheduler/encrypted_column'
 
 class User < ActiveRecord::Base
   has_one :subscription, as: :owner
+  serialize :github_oauth_token, Travis::Scheduler::EncryptedColumn.new
 
   def subscribed?
     subscription.present? and subscription.active?

--- a/lib/travis/scheduler/schedule.rb
+++ b/lib/travis/scheduler/schedule.rb
@@ -7,6 +7,7 @@ require 'travis/scheduler/helpers/locking'
 require 'travis/scheduler/services/enqueue_jobs'
 require 'travis/support/exceptions'
 require 'travis/scheduler/support/sidekiq'
+require 'travis/scheduler/github'
 
 module Travis
   module Scheduler
@@ -21,6 +22,7 @@ module Travis
         Travis::Metrics.setup
         Support::Sidekiq.setup(config)
         Support::Features.setup(config)
+        Travis::Scheduler::Github.setup
 
         declare_exchanges_and_queues
       end

--- a/spec/travis/scheduler/branch_validator_spec.rb
+++ b/spec/travis/scheduler/branch_validator_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+
+describe Travis::Scheduler::BranchValidator do
+  #let(:repo)    { FactoryGirl.create(:repository, owner_name: 'travis-ci', name: 'travis-ci') }
+  #let(:commit)  { Commit.new(commit: '12345678') }
+  #let(:request) { Request.new(repository: repo, commit: commit) }
+
+  describe '#valid_branch_name?' do
+    it 'validates the name' do
+      expect(described_class.new('foo', nil).valid_branch_name?).to be_truthy
+      expect(described_class.new('foo/bar/baz', nil).valid_branch_name?).to be_truthy
+      expect(described_class.new('foo-bar.baz/1.0.1', nil).valid_branch_name?).to be_truthy
+      expect(described_class.new('1.2.3', nil).valid_branch_name?).to be_truthy
+      expect(described_class.new('a/b-c/d', nil).valid_branch_name?).to be_truthy
+
+      expect(described_class.new('a/.b', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo.lock', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo.', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo^', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new(nil, nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('/foo', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo//bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo@bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo^bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo[bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo*bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo?bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo:bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo~bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new('foo\bar', nil).valid_branch_name?).to be_falsey
+      expect(described_class.new("foo\040bar", nil).valid_branch_name?).to be_falsey
+      expect(described_class.new("foo\177bar", nil).valid_branch_name?).to be_falsey
+    end
+  end
+
+  describe 'branch_exists_in_the_db?' do
+    it 'returns ture if a branch with a given name and repository id exists in the database' do
+      Branch.create(name: 'foo', repository_id: 10)
+
+      repository = stub(id: 10)
+      expect(described_class.new('foo', repository).branch_exists_in_the_db?).to be_truthy
+    end
+
+    it 'returns ture if a branch with a given name and repository id does not exist in the database' do
+      Branch.create(name: 'foo', repository_id: 11)
+
+      repository = stub(id: 10)
+      expect(described_class.new('foo', repository).branch_exists_in_the_db?).to be_falsey
+    end
+  end
+
+  describe 'branch_exists_on_github?' do
+    it 'tries to fetch branch from github using credentials of recently updated user' do
+      repository = FactoryGirl.create(:repository, name: 'travis-scheduler', owner_name: 'travis-ci', private: true)
+      user1 = FactoryGirl.create(:user, updated_at: Time.now, github_oauth_token: 'token-1')
+      user2 = FactoryGirl.create(:user, updated_at: Time.now - 3600, github_oauth_token: 'token-2')
+      repository.users << user1
+      repository.users << user2
+
+      GH.expects(:with).with(token: 'token-1').yields
+      GH.expects(:[]).with('/repos/travis-ci/travis-scheduler/branches/foo').returns({})
+
+      expect(described_class.new('foo', repository).branch_exists_on_github?).to be_truthy
+    end
+
+    it 'tries to fetch branch from github using credentials of next users if the first user\'s token is invalid' do
+      repository = FactoryGirl.create(:repository, name: 'travis-scheduler', owner_name: 'travis-ci', private: true)
+      user1 = FactoryGirl.create(:user, updated_at: Time.now, github_oauth_token: 'token-1')
+      user2 = FactoryGirl.create(:user, updated_at: Time.now - 3600, github_oauth_token: 'token-2')
+      repository.users << user1
+      repository.users << user2
+
+      GH.expects(:with).with(token: 'token-1').raises(GH::TokenInvalid)
+      GH.expects(:with).with(token: 'token-2').yields
+      GH.expects(:[]).with('/repos/travis-ci/travis-scheduler/branches/foo').returns({})
+
+      expect(described_class.new('foo', repository).branch_exists_on_github?).to be_truthy
+    end
+
+    it "returns false if all of the users' tokens are invalid" do
+      repository = FactoryGirl.create(:repository, name: 'travis-scheduler', owner_name: 'travis-ci', private: true)
+      user1 = FactoryGirl.create(:user, updated_at: Time.now, github_oauth_token: 'token-1')
+      user2 = FactoryGirl.create(:user, updated_at: Time.now - 3600, github_oauth_token: 'token-2')
+      repository.users << user1
+      repository.users << user2
+
+      GH.expects(:with).with(token: 'token-1').raises(GH::TokenInvalid)
+      GH.expects(:with).with(token: 'token-2').raises(GH::TokenInvalid)
+
+      expect(described_class.new('foo', repository).branch_exists_on_github?).to be_falsey
+    end
+
+    it 'returns false if the branch does not exist on github' do
+      repository = FactoryGirl.create(:repository, name: 'travis-scheduler', owner_name: 'travis-ci', private: true)
+
+      user1 = FactoryGirl.create(:user, updated_at: Time.now, github_oauth_token: 'token-1')
+      user2 = FactoryGirl.create(:user, updated_at: Time.now - 3600, github_oauth_token: 'token-2')
+      repository.users << user1
+      repository.users << user2
+
+      GH.expects(:with).with(token: 'token-1').raises(GH::TokenInvalid)
+      GH.expects(:with).with(token: 'token-2').yields
+      GH.expects(:[]).with('/repos/travis-ci/travis-scheduler/branches/foo').raises(GH::Error.new(nil, nil, response_status: 404))
+
+      expect(described_class.new('foo', repository).branch_exists_on_github?).to be_falsey
+    end
+
+    it "tries next users even if we get 404 or 403 (because user's permissions could be revoked)" do
+      repository = FactoryGirl.create(:repository, name: 'travis-scheduler', owner_name: 'travis-ci', private: true)
+
+      user1 = FactoryGirl.create(:user, updated_at: Time.now, github_oauth_token: 'token-1')
+      user2 = FactoryGirl.create(:user, updated_at: Time.now - 100, github_oauth_token: 'token-2')
+      user3 = FactoryGirl.create(:user, updated_at: Time.now - 200, github_oauth_token: 'token-3')
+      repository.users << user1
+      repository.users << user2
+      repository.users << user3
+
+      GH.expects(:with).with(token: 'token-1').yields
+      GH.expects(:with).with(token: 'token-2').yields
+      GH.expects(:with).with(token: 'token-3').yields
+      sequence = sequence('sequence')
+      GH.expects(:[]).with('/repos/travis-ci/travis-scheduler/branches/foo').raises(GH::Error.new(nil, nil, response_status: 404)).in_sequence(sequence)
+      GH.expects(:[]).with('/repos/travis-ci/travis-scheduler/branches/foo').raises(GH::Error.new(nil, nil, response_status: 403)).in_sequence(sequence)
+      GH.expects(:[]).with('/repos/travis-ci/travis-scheduler/branches/foo').returns({}).in_sequence(sequence)
+
+      expect(described_class.new('foo', repository).branch_exists_on_github?).to be_truthy
+    end
+
+    it "raises an error if it's a non 403 or 404 error" do
+      repository = FactoryGirl.create(:repository, name: 'travis-scheduler', owner_name: 'travis-ci', private: true)
+
+      user1 = FactoryGirl.create(:user, updated_at: Time.now, github_oauth_token: 'token-1')
+      repository.users << user1
+
+      GH.expects(:with).with(token: 'token-1').yields
+      GH.expects(:[]).times(3).with('/repos/travis-ci/travis-scheduler/branches/foo').raises(GH::Error.new(nil, nil, response_status: 401))
+
+      expect {
+        described_class.new('foo', repository).branch_exists_on_github?
+      }.to raise_error(GH::Error)
+    end
+  end
+end

--- a/spec/travis/scheduler/models/request_spec.rb
+++ b/spec/travis/scheduler/models/request_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Request do
-  let(:repo)    { Repository.new(owner_name: 'travis-ci', name: 'travis-ci') }
+  let(:repo)    { FactoryGirl.create(:repository, owner_name: 'travis-ci', name: 'travis-ci') }
   let(:commit)  { Commit.new(commit: '12345678') }
   let(:request) { Request.new(repository: repo, commit: commit) }
 
@@ -50,11 +50,40 @@ describe Request do
   end
 
   describe 'same_repo_pull_request?' do
-    it 'returns true if the base and head repos match' do
+    it 'returns false if the ref is a sha' do
       request.payload = {
         'pull_request' => {
           'base' => { 'repo' => { 'full_name' => 'travis-ci/travis-core' } },
-          'head' => { 'repo' => { 'full_name' => 'travis-ci/travis-core' } }
+          'head' => { 'repo' => { 'full_name' => 'travis-ci/travis-core' },
+                      'ref' => 'abc123', 'sha' => 'abc123bde266593ee3a9d32d376430437a6fc392' }
+        }
+      }
+
+      expect(request.same_repo_pull_request?).to eq(false)
+    end
+
+    it 'calls the branch valdiator if it looks like a same repo PR and ref does not look like a sha' do
+      request.payload = {
+        'pull_request' => {
+          'base' => { 'repo' => { 'full_name' => 'travis-ci/travis-core' } },
+          'head' => { 'repo' => { 'full_name' => 'travis-ci/travis-core' },
+                      'ref' => 'foo', 'sha' => 'abc123bde266593ee3a9d32d376430437a6fc392' }
+        }
+      }
+
+      validator  = stub(valid?: true)
+      Travis::Scheduler::BranchValidator.expects(:new).with('foo', request.repository).returns(validator)
+      expect(request.same_repo_pull_request?).to eq(true)
+    end
+
+    # integration for branch validator
+    it 'returns true if the branch exists in the db' do
+      Branch.create(repository_id: repo.id, name: 'foo')
+      request.payload = {
+        'pull_request' => {
+          'base' => { 'repo' => { 'full_name' => 'travis-ci/travis-core' } },
+          'head' => { 'repo' => { 'full_name' => 'travis-ci/travis-core' },
+                      'ref' => 'foo', 'sha' => 'abc123bde266593ee3a9d32d376430437a6fc392' }
         }
       }
 


### PR DESCRIPTION
Due to a security incident we've forked the open travis-ci/travis-scheduler
to the closed travis-pro/travis-scheduler and started using that one for development.

Since the incident is now published we can move back to the old (open) repository.