### PR TITLE
Allow Browserstack addon in PR builds

### DIFF
--- a/lib/travis/scheduler/models/job/config/normalize.rb
+++ b/lib/travis/scheduler/models/job/config/normalize.rb
@@ -5,6 +5,7 @@ class Job
         apt
         apt_packages
         apt_sources
+        browserstack
         firefox
         hostname
         hosts


### PR DESCRIPTION
To correspond to https://github.com/travis-ci/travis-build/pull/702.