### PR TITLE
Use HTTPS URL when "prefer_https" is configured

### DIFF
--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -22,7 +22,8 @@ module Travis
               ssl:           { },
               cache_settings: { },
               queue_redirections: { },
-              oauth2:        { }
+              oauth2:        { },
+              prefer_https:  false
     end
   end
 end

--- a/lib/travis/scheduler/models/repository.rb
+++ b/lib/travis/scheduler/models/repository.rb
@@ -40,7 +40,7 @@ class Repository < ActiveRecord::Base
   end
 
   def admin
-    candidates = repository.users.where("github_oauth_token IS NOT NULL").
+    candidates = users.where("github_oauth_token IS NOT NULL").
                                   order("updated_at DESC")
 
     candidates.first

--- a/lib/travis/scheduler/models/repository.rb
+++ b/lib/travis/scheduler/models/repository.rb
@@ -40,15 +40,10 @@ class Repository < ActiveRecord::Base
   end
 
   def admin
-    candicates = User.with_github_token.with_permissions(:repository_id => id, :admin => true).first
-    admin = candicates.first
+    candidates = repository.users.where("github_oauth_token IS NOT NULL").
+                                  order("updated_at DESC")
 
-    admin || begin
-      Travis.logger.error("[github-scheduler] repository #{slug} does not have admin")
-      nil
-    end
-  rescue
-    nil
+    candidates.first
   end
 end
 

--- a/lib/travis/scheduler/models/repository.rb
+++ b/lib/travis/scheduler/models/repository.rb
@@ -24,7 +24,7 @@ class Repository < ActiveRecord::Base
   end
 
   def source_url
-    private? || force_private? ? "git@#{source_host}:#{slug}.git": "https://#{source_host}/#{slug}.git"
+    ( private? || force_private? ) && !Travis.config.prefer_https ? "git@#{source_host}:#{slug}.git": "https://#{source_host}/#{slug}.git"
   end
 
   def force_private?

--- a/lib/travis/scheduler/models/user.rb
+++ b/lib/travis/scheduler/models/user.rb
@@ -4,9 +4,20 @@ require 'travis/scheduler/encrypted_column'
 
 class User < ActiveRecord::Base
   has_one :subscription, as: :owner
+  has_many :permissions
   serialize :github_oauth_token, Travis::Scheduler::EncryptedColumn.new
 
   def subscribed?
     subscription.present? and subscription.active?
+  end
+
+  class << self
+    def with_permissions(permissions)
+      where(:permissions => permissions).includes(:permissions)
+    end
+
+    def with_github_token
+      where("github_oauth_token IS NOT NULL and github_oauth_token != ''")
+    end
   end
 end

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -159,7 +159,7 @@ module Travis
         end
 
         def oauth_token
-          repository.admin.github_oauth_token
+          repository.admin && repository.admin.github_oauth_token
         end
       end
     end

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -45,7 +45,7 @@ module Travis
           }
 
           if prefer_https?
-            data['oauth_token'] = repository.admin.github_oauth_token
+            data['oauth_token'] = oauth_token
           end
 
           if Support::Features.active?(:cache_settings, repository)
@@ -156,6 +156,10 @@ module Travis
 
         def prefer_https?
           Travis.config.prefer_https || false
+        end
+
+        def oauth_token
+          repository.admin.github_oauth_token
         end
       end
     end

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -44,6 +44,10 @@ module Travis
             'prefer_https' => prefer_https?
           }
 
+          if prefer_https?
+            data['oauth_token'] = repository.admin.github_oauth_token
+          end
+
           if Support::Features.active?(:cache_settings, repository)
             if Travis.config.cache_settings && queue_settings = Travis.config.cache_settings.to_h.fetch(job.queue && job.queue.to_sym, nil)
               data.merge!({ 'cache_settings' => queue_settings })

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -41,6 +41,7 @@ module Travis
             'ssh_key' => ssh_key,
             'env_vars' => env_vars,
             'timeouts' => timeouts,
+            'prefer_https' => prefer_https?
           }
 
           if Support::Features.active?(:cache_settings, repository)
@@ -147,6 +148,10 @@ module Travis
         def secure_env?
           return @secure_env if defined? @secure_env
           @secure_env = job.secure_env?
+        end
+
+        def prefer_https?
+          Travis.config.prefer_https
         end
       end
     end

--- a/lib/travis/scheduler/payloads/worker.rb
+++ b/lib/travis/scheduler/payloads/worker.rb
@@ -151,7 +151,7 @@ module Travis
         end
 
         def prefer_https?
-          Travis.config.prefer_https
+          Travis.config.prefer_https || false
         end
       end
     end

--- a/spec/travis/scheduler/models/repository_spec.rb
+++ b/spec/travis/scheduler/models/repository_spec.rb
@@ -21,6 +21,7 @@ describe Repository do
 
       before :each do
         Travis.config.github.source_host = nil
+        repo.stubs(:admin).returns User.new
       end
 
       it 'returns the public git source url for a public repository' do
@@ -59,7 +60,11 @@ describe Repository do
     context 'when prefer_https is set' do
       let(:repo) { Repository.new(owner_name: 'travis-ci', name: 'travis-ci') }
 
-      before { Travis.config.prefer_https = true  }
+      before :each do
+        Travis.config.prefer_https = true
+        repo.stubs(:admin).returns User.new
+      end
+
       after  { Travis.config.prefer_https = false }
 
       it 'returns the https source url the repository' do

--- a/spec/travis/scheduler/models/repository_spec.rb
+++ b/spec/travis/scheduler/models/repository_spec.rb
@@ -41,6 +41,10 @@ describe Repository do
         Travis.config.github.source_host = 'localhost'
       end
 
+      after :each do
+        Travis.config.github.source_host = nil
+      end
+
       it 'returns the private git source url for a public repository' do
         repo.private = false
         expect(repo.source_url).to eq('git@localhost:travis-ci/travis-ci.git')
@@ -49,6 +53,17 @@ describe Repository do
       it 'returns the private git source url for a private repository' do
         repo.private = true
         expect(repo.source_url).to eq('git@localhost:travis-ci/travis-ci.git')
+      end
+    end
+
+    context 'when prefer_https is set' do
+      let(:repo) { Repository.new(owner_name: 'travis-ci', name: 'travis-ci') }
+
+      before { Travis.config.prefer_https = true  }
+      after  { Travis.config.prefer_https = false }
+
+      it 'returns the https source url the repository' do
+        expect(repo.source_url).to eq('https://github.com/travis-ci/travis-ci.git')
       end
     end
   end

--- a/spec/travis/scheduler/payloads/worker_spec.rb
+++ b/spec/travis/scheduler/payloads/worker_spec.rb
@@ -148,6 +148,40 @@ describe Travis::Scheduler::Payloads::Worker do
         it { expect(data['vm_type']).to eq('premium') }
       end
     end
+
+    context 'when prefer_https is set in config' do
+      before { Travis.config.prefer_https = true  }
+      after  { Travis.config.prefer_https = false }
+
+      it 'contains the expected data' do
+        expect(data.except('job', 'build', 'repository')).to eq(
+          'type' => 'test',
+          'vm_type' => 'default',
+          'config' => {
+            'rvm' => '1.8.7',
+            'gemfile' => 'test/Gemfile.rails-2.3.x'
+          },
+          'queue' => 'builds.linux',
+          'ssh_key' => nil,
+          'source' => {
+            'id' => 1,
+            'number' => 2,
+            'event_type' => 'push'
+          },
+          'env_vars' => [
+            { 'name' => 'FOO', 'value' => 'bar', 'public' => false },
+            { 'name' => 'BAR', 'value' => 'baz', 'public' => true }
+          ],
+          'timeouts' => {
+            'hard_limit' => 180 * 60, # worker handles timeouts in seconds
+            'log_silence' => 20 * 60
+          },
+          'cache_settings' => cache_settings_linux,
+          'prefer_https' => true,
+          'oauth_token' => "token"
+        )
+      end
+    end
   end
 
   describe 'for a debug build request' do

--- a/spec/travis/scheduler/payloads/worker_spec.rb
+++ b/spec/travis/scheduler/payloads/worker_spec.rb
@@ -66,7 +66,8 @@ describe Travis::Scheduler::Payloads::Worker do
           'hard_limit' => 180 * 60, # worker handles timeouts in seconds
           'log_silence' => 20 * 60
         },
-        'cache_settings' => cache_settings_linux
+        'cache_settings' => cache_settings_linux,
+        'prefer_https' => false
       )
     end
 
@@ -191,7 +192,8 @@ describe Travis::Scheduler::Payloads::Worker do
           'hard_limit' => 180 * 60, # worker handles timeouts in seconds
           'log_silence' => 20 * 60
         },
-        'cache_settings' => cache_settings_linux
+        'cache_settings' => cache_settings_linux,
+        'prefer_https' => false
       )
     end
 


### PR DESCRIPTION
This PR as a system wide config `prefer_https`, which adds the value to the payload and modifies the repository's `source_url`, which influences `travis-build` when it tries to clone the repository.

The corresponding changes in `travis-build` is https://github.com/travis-ci/travis-build/pull/804.
