### PR TITLE
Suppress `[nil]` when it bubbles up in config

### DIFF
--- a/lib/travis/scheduler/models/job/config/normalize.rb
+++ b/lib/travis/scheduler/models/job/config/normalize.rb
@@ -49,7 +49,7 @@ class Job
         end
 
         def normalize_env(env)
-          [env].flatten.map do |line|
+          [env].flatten.compact.map do |line|
             if line.is_a?(Hash) && !line.has_key?(:secure)
               line.map { |k, v| "#{k}=#{v}" }.join(' ')
             else

--- a/spec/travis/scheduler/models/job_config_spec.rb
+++ b/spec/travis/scheduler/models/job_config_spec.rb
@@ -35,6 +35,11 @@ describe Job::Config do
       let(:config) { { rvm: '1.8.7', env: nil, global_env: nil } }
       it { should eql(config) }
     end
+
+    describe 'with a [nil] env' do
+      let(:config) { { rvm: '1.8.7', env: [ nil ], global_env: [ nil ] } }
+      it { should eql({ rvm: '1.8.7', env: [], global_env: [] }) }
+    end
   end
 
   describe 'with secure env enabled' do


### PR DESCRIPTION
This commit addresses the following problem:

This .travis.yml

```
env:
global:
- FOO=BAR
matrix:
-
matrix:
include:
- rvm: 2.3.0
gemfile: gemfiles/Gemfile.sinatra-edge
```

results in config

{:env=>[nil], :global_env=> ["FOO=BAR"]}

when it comes down to travis-scheduler.

Hitherto, we yielded

config[:env] = [{}, "FOO=BAR"]

which leads to problematic travis-build:

An error occurred while compiling the build script: undefined method `start_with?' for {}:Hash

See https://travis-ci.org/BanzaiMan/travis_production_test/jobs/148201050