### PR TITLE
Keep unencrypted addon config for jwt-aware addons if jwt is present

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --colour
 --tty
---format documentation
 --require spec_helper

--- a/lib/travis/scheduler/models/job/config.rb
+++ b/lib/travis/scheduler/models/job/config.rb
@@ -1,4 +1,5 @@
 require 'travis/scheduler/helpers/deep_dup'
+require 'travis/scheduler/models/job/config/addons'
 require 'travis/scheduler/models/job/config/decrypt'
 require 'travis/scheduler/models/job/config/normalize'
 

--- a/lib/travis/scheduler/models/job/config/addons.rb
+++ b/lib/travis/scheduler/models/job/config/addons.rb
@@ -1,0 +1,76 @@
+class Job
+  module Config
+    class Addons < Struct.new(:config)
+      SAFE = %i(
+        apt
+        apt_packages
+        apt_sources
+        browserstack
+        firefox
+        hostname
+        hosts
+        jwt
+        mariadb
+        postgresql
+        rethinkdb
+        ssh_known_hosts
+      )
+
+      JWT_AWARE = %i(
+        sauce_connect
+      )
+
+      def apply
+        config = compact(filtered)
+        config unless config.empty?
+      end
+
+      private
+
+        def filtered
+          config.map { |key, value| [key, filter(key, value)] }.to_h
+        end
+
+        def filter(name, config)
+          if safe?(name)
+            config
+          elsif jwt? && jwt_aware?(name)
+            strip_encrypted(config)
+          else
+            nil
+          end
+        end
+
+        def strip_encrypted(config)
+          case config
+          when Hash
+            compact(config.map { |key, value| [key, encrypted?(value) ? nil : value] }).to_h
+          when Array
+            config.map { |config| strip_encrypted(config) }
+          else
+            config
+          end
+        end
+
+        def safe?(name)
+          SAFE.include?(name.to_sym)
+        end
+
+        def jwt?
+          config.keys.include?(:jwt)
+        end
+
+        def jwt_aware?(name)
+          JWT_AWARE.include?(name.to_sym)
+        end
+
+        def encrypted?(value)
+          value.is_a?(Hash) && value.keys.any? { |key| key == :secure }
+        end
+
+        def compact(hash)
+          hash.reject { |_, value| value.nil? }
+        end
+    end
+  end
+end

--- a/lib/travis/scheduler/models/job/config/normalize.rb
+++ b/lib/travis/scheduler/models/job/config/normalize.rb
@@ -1,7 +1,7 @@
 class Job
   module Config
     class Normalize
-      WHITELISTED_ADDONS = %w(
+      SAFE_ADDONS = %w(
         apt
         apt_packages
         apt_sources
@@ -28,7 +28,7 @@ class Job
         normalize_deploy if config[:deploy]
         normalize_addons
         filter_addons    if config[:addons] && !full_addons?
-        config
+        compact(config)
       end
 
       private
@@ -68,8 +68,11 @@ class Job
         end
 
         def filter_addons
-          config[:addons].keep_if { |key, _| WHITELISTED_ADDONS.include? key.to_s }
-          config.delete(:addons) if config[:addons].empty?
+          config[:addons] = Addons.new(config[:addons]).apply
+        end
+
+        def compact(hash)
+          hash.reject { |_, value| value.nil? }
         end
     end
   end

--- a/spec/travis/scheduler/models/job_config_spec.rb
+++ b/spec/travis/scheduler/models/job_config_spec.rb
@@ -33,7 +33,7 @@ describe Job::Config do
 
     describe 'with a nil env' do
       let(:config) { { rvm: '1.8.7', env: nil, global_env: nil } }
-      it { should eql(config) }
+      it { should eql(rvm: '1.8.7') }
     end
 
     describe 'with a [nil] env' do
@@ -118,7 +118,7 @@ describe Job::Config do
       end
     end
 
-    Job::Config::Normalize::WHITELISTED_ADDONS.map(&:to_sym).each do |name|
+    Job::Config::Addons::SAFE.map(&:to_sym).each do |name|
       describe "keeps the #{name} addon" do
         let(:config) { { addons: { name => :config } } }
         it { should eql(config) }
@@ -127,8 +127,8 @@ describe Job::Config do
 
     describe 'jwt encrypted env var' do
       let(:var)    { 'SAUCE_ACCESS_KEY=foo' }
-      let(:config) { { addons: { jwt: encrypt(var) } } }
-      it { should eql(addons: { jwt: var }) }
+      let(:config) { { addons: { jwt: encrypt(var), sauce_connect: { foo: 'foo', bar: encrypt('other') } } } }
+      it { should eql(addons: { jwt: var, sauce_connect: { foo: 'foo' } }) }
     end
   end
 


### PR DESCRIPTION
Re https://github.com/travis-pro/team-teal/issues/1314

Given a config:

```
addons:
  jwt: ...
  sauce_connect:
    keep: something
    remove:
      secure: encrypted
```

It would keep the `keep` key, but remove `remove`:

```
{ addons: { jwt: ..., sauce_connect: { keep: 'something' } } }
```

Also, given a config:

```
addons:
  jwt: [...]
  sauce_connect: true
```

It would keep the `sauce_connect` key:

```
{ addons: { jwt: ..., sauce_connect: true } }
```

Not sure if this latter case helps at all, but I guess travis-build would also enable the sauce_connect addon?
