### PR TITLE
Keep unencrypted addon config for jwt-aware addons if jwt is present

### DIFF
--- a/lib/travis/scheduler/serialize/worker/config.rb
+++ b/lib/travis/scheduler/serialize/worker/config.rb
@@ -1,4 +1,5 @@
 require 'travis/scheduler/helper/deep_dup'
+require 'travis/scheduler/serialize/worker/config/addons'
 require 'travis/scheduler/serialize/worker/config/decrypt'
 require 'travis/scheduler/serialize/worker/config/normalize'
 

--- a/lib/travis/scheduler/serialize/worker/config/addons.rb
+++ b/lib/travis/scheduler/serialize/worker/config/addons.rb
@@ -1,0 +1,81 @@
+module Travis
+  module Scheduler
+    module Serialize
+      class Worker
+        module Config
+          class Addons < Struct.new(:config)
+            SAFE = %i(
+              apt
+              apt_packages
+              apt_sources
+              browserstack
+              firefox
+              hostname
+              hosts
+              jwt
+              mariadb
+              postgresql
+              rethinkdb
+              ssh_known_hosts
+            )
+
+            JWT_AWARE = %i(
+              sauce_connect
+            )
+
+            def apply
+              config = compact(filtered)
+              config unless config.empty?
+            end
+
+            private
+            def filtered
+              config.map { |key, value| [key, filter(key, value)] }.to_h
+            end
+
+            def filter(name, config)
+              if safe?(name)
+                config
+              elsif jwt? && jwt_aware?(name)
+                strip_encrypted(config)
+              else
+                nil
+              end
+            end
+
+            def strip_encrypted(config)
+              case config
+              when Hash
+                compact(config.map { |key, value| [key, encrypted?(value) ? nil : value] }).to_h
+              when Array
+                config.map { |config| strip_encrypted(config) }
+              else
+                config
+              end
+            end
+
+            def safe?(name)
+              SAFE.include?(name.to_sym)
+            end
+
+            def jwt?
+              config.keys.include?(:jwt)
+            end
+
+            def jwt_aware?(name)
+              JWT_AWARE.include?(name.to_sym)
+            end
+
+            def encrypted?(value)
+              value.is_a?(Hash) && value.keys.any? { |key| key == :secure }
+            end
+
+            def compact(hash)
+              hash.reject { |_, value| value.nil? }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/scheduler/serialize/worker/config/normalize.rb
+++ b/lib/travis/scheduler/serialize/worker/config/normalize.rb
@@ -4,7 +4,7 @@ module Travis
       class Worker
         module Config
           class Normalize
-            WHITELISTED_ADDONS = %w(
+            SAFE_ADDONS = %w(
               apt
               apt_packages
               apt_sources
@@ -31,7 +31,7 @@ module Travis
               normalize_deploy if config[:deploy]
               normalize_addons
               filter_addons    if config[:addons] && !full_addons?
-              config
+              compact(config)
             end
 
             private
@@ -71,8 +71,11 @@ module Travis
               end
 
               def filter_addons
-                config[:addons].keep_if { |key, _| WHITELISTED_ADDONS.include? key.to_s }
-                config.delete(:addons) if config[:addons].empty?
+                config[:addons] = Addons.new(config[:addons]).apply
+              end
+
+              def compact(hash)
+                hash.reject { |_, value| value.nil? }
               end
           end
         end

--- a/spec/travis/scheduler/serialize/worker/config_spec.rb
+++ b/spec/travis/scheduler/serialize/worker/config_spec.rb
@@ -31,7 +31,7 @@ describe Travis::Scheduler::Serialize::Worker::Config do
 
     describe 'with a nil env' do
       let(:config) { { rvm: '1.8.7', env: nil, global_env: nil } }
-      it { should eql(config) }
+      it { should eql(rvm: '1.8.7') }
     end
 
     describe 'with a [nil] env' do
@@ -116,7 +116,7 @@ describe Travis::Scheduler::Serialize::Worker::Config do
       end
     end
 
-    described_class::Normalize::WHITELISTED_ADDONS.map(&:to_sym).each do |name|
+    described_class::Addons::SAFE.map(&:to_sym).each do |name|
       describe "keeps the #{name} addon" do
         let(:config) { { addons: { name => :config } } }
         it { should eql(config) }


### PR DESCRIPTION
This is basically a port of
https://github.com/travis-ci/travis-scheduler/pull/34 to scheduler-2.

See that PR for rationale.