### PR TITLE
Allow sonarqube addon on external PRs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
-console:  bundle exec je ./bin/console
-sidekiq:  bundle exec je bin/sidekiq ${SIDEKIQ_CONCURRENCY:-5} ${SIDEKIQ_QUEUE:-scheduler}
+console:   bundle exec je ./bin/console
+sidekiq:   bundle exec je bin/sidekiq ${SIDEKIQ_CONCURRENCY:-5} ${SIDEKIQ_QUEUE:-scheduler}
+scheduler: bundle exec je bin/sidekiq ${SIDEKIQ_CONCURRENCY:-5} ${SIDEKIQ_QUEUE:-scheduler}

--- a/lib/travis/scheduler/serialize/worker/config/addons.rb
+++ b/lib/travis/scheduler/serialize/worker/config/addons.rb
@@ -16,6 +16,7 @@ module Travis
               mariadb
               postgresql
               rethinkdb
+              sonarqube
               ssh_known_hosts
             )
 


### PR DESCRIPTION
In this case, addon runs without sensitive data

See https://github.com/travis-ci/travis-build/pull/831#issuecomment-250726456.
