### PR TITLE
Limit by trial

### DIFF
--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -10,7 +10,7 @@ module Travis
              enterprise: false,
              github:     { api_url: 'https://api.github.com', source_host: 'github.com' },
              interval:   2,
-             limit:      { strategy: 'default', default: 5, by_owner: {}, delegate: {} },
+             limit:      { default: 5, by_owner: {}, delegate: {} },
              lock:       { strategy: :redis, ttl: 150 },
              logger:     { time_format: false, process_id: false, thread_id: false },
              log_level:  :info,

--- a/lib/travis/scheduler/helper/memoize.rb
+++ b/lib/travis/scheduler/helper/memoize.rb
@@ -1,0 +1,23 @@
+module Travis
+  module Scheduler
+    module Helper
+      module Memoize
+        module ClassMethods
+          def memoize(name)
+            prepend Module.new {
+              define_method(name) do |*args, &block|
+                var = "@#{name.to_s.gsub(/[\W]/, '')}"
+                return instance_variable_get(var) if instance_variable_defined?(var)
+                instance_variable_set(var, super(*args, &block))
+              end
+            }
+          end
+        end
+
+        def self.included(base)
+          base.extend(ClassMethods)
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/scheduler/model/trial.rb
+++ b/lib/travis/scheduler/model/trial.rb
@@ -1,0 +1,32 @@
+require 'travis/scheduler/helper/memoize'
+
+module Travis
+  module Scheduler
+    module Model
+      class Trial < Struct.new(:owners, :redis)
+        include Helper::Memoize
+
+        def active?
+          count && count > -1
+        end
+
+        private
+
+          def count
+            counts.compact.map(&:to_i).max
+          end
+          memoize :count
+
+          def counts
+            owners.logins.map do |login|
+              redis.get(key_for(login))
+            end
+          end
+
+          def key_for(login)
+            "trial:#{login}"
+          end
+      end
+    end
+  end
+end

--- a/spec/travis/scheduler/helper/memoize_spec.rb
+++ b/spec/travis/scheduler/helper/memoize_spec.rb
@@ -1,0 +1,18 @@
+describe Travis::Scheduler::Helper::Memoize do
+  let :const do
+    Class.new(Struct.new(:dep)) do
+      include Travis::Scheduler::Helper::Memoize
+      memoize def foo; dep.call; end
+    end
+  end
+
+  let(:dep) { stub('dep') }
+  let(:obj) { const.new(dep) }
+
+  [true, false, nil].each do |val|
+    it "calls the implementation only once (returning #{val}" do
+      dep.expects(:call).returns(val).once
+      3.times { expect(obj.foo).to eq val }
+    end
+  end
+end


### PR DESCRIPTION
We currently use the same default config value for both trial and educational accounts. This allows setting a separate limit for trial builds.