### PR TITLE
Allow sonarqube addon on external PRs

### DIFF
--- a/lib/travis/scheduler/serialize/worker/config/addons.rb
+++ b/lib/travis/scheduler/serialize/worker/config/addons.rb
@@ -16,6 +16,7 @@ module Travis
               mariadb
               postgresql
               rethinkdb
+              sonarqube
               ssh_known_hosts
             )
 


### PR DESCRIPTION
In this case, addon runs without sensitive data