### PR TITLE
Add PR slug name to payload

### DIFF
--- a/lib/travis/scheduler/serialize/worker.rb
+++ b/lib/travis/scheduler/serialize/worker.rb
@@ -55,6 +55,7 @@ module Travis
               data = data.merge(
                 pull_request_head_branch: request.pull_request_head_branch,
                 pull_request_head_sha: request.pull_request_head_sha,
+                pull_request_head_slug: request.pull_request_head_slug,
               )
             end
             data

--- a/lib/travis/scheduler/serialize/worker/request.rb
+++ b/lib/travis/scheduler/serialize/worker/request.rb
@@ -22,7 +22,7 @@ module Travis
           end
 
           def pull_request_head_slug
-            pull_request_head['repo']['full_name']
+            pull_request_head['repo'] && pull_request_head['repo']['full_name']
           end
 
           def pull_request_head

--- a/lib/travis/scheduler/serialize/worker/request.rb
+++ b/lib/travis/scheduler/serialize/worker/request.rb
@@ -21,6 +21,10 @@ module Travis
             pull_request_head['sha']
           end
 
+          def pull_request_head_slug
+            pull_request_head['repo']['full_name']
+          end
+
           def pull_request_head
             payload && payload['pull_request'] && payload['pull_request']['head'] || {}
           end

--- a/spec/travis/scheduler/serialize/worker_spec.rb
+++ b/spec/travis/scheduler/serialize/worker_spec.rb
@@ -115,7 +115,7 @@ describe Travis::Scheduler::Serialize::Worker do
     let(:event)     { 'pull_request' }
     let(:ref)       { 'refs/pull/180/merge' }
     let(:pr_number) { 180 }
-    let(:payload)   { { 'pull_request' => { 'head' => { 'ref' => 'head_branch', 'sha' => '12345' } } } }
+    let(:payload)   { { 'pull_request' => { 'head' => { 'ref' => 'head_branch', 'sha' => '12345', 'repo' => {'full_name' => 'travis-ci/gem-release'} } } } }
 
     before :each do
       request.stubs(:base_commit).returns('0cd9ff')
@@ -148,7 +148,8 @@ describe Travis::Scheduler::Serialize::Worker do
           secure_env_enabled: false,
           debug_options: {},
           pull_request_head_branch: 'head_branch',
-          pull_request_head_sha: '12345'
+          pull_request_head_sha: '12345',
+          pull_request_head_slug: 'travis-ci/gem-release',
         },
         source: {
           id: build.id,


### PR DESCRIPTION
We add the "full_name" of the repository which initiated the PR.

See https://developer.github.com/v3/pulls/#get-a-single-pull-request
for the structure of the PR data we receive from GitHub.