### PR TITLE
Add a queue matcher for multiple owners

### DIFF
--- a/lib/travis/queue/matcher.rb
+++ b/lib/travis/queue/matcher.rb
@@ -1,8 +1,8 @@
 module Travis
   class Queue
     class Matcher < Struct.new(:job, :config, :logger)
-      KEYS = %i(slug owner os language sudo dist group osx_image percentage
-        services)
+      KEYS = %i(slug owner owners os language sudo dist group osx_image
+                percentage services)
 
       MSGS = {
         unknown_matchers: 'unknown matchers used for queue %s: %s (repo=%s)"'
@@ -25,6 +25,10 @@ module Travis
 
         def owner
           repo.owner_name
+        end
+
+        def owners
+          ->(owners) { Array(owners).include?(repo.owner_name) }
         end
 
         def os

--- a/spec/travis/queue_spec.rb
+++ b/spec/travis/queue_spec.rb
@@ -24,7 +24,8 @@ describe Travis::Queue do
       { queue: 'builds.mac_stable', osx_image: 'stable' },
       { queue: 'builds.mac_beta', osx_image: 'beta' },
       { queue: 'builds.new-foo', language: 'foo', percentage: percent },
-      { queue: 'builds.old-foo', language: 'foo' }
+      { queue: 'builds.old-foo', language: 'foo' },
+      { queue: 'builds.multi-owner', owners: ['foo', 'bar'] },
     ]
   end
 
@@ -54,6 +55,11 @@ describe Travis::Queue do
     describe 'by owner name' do
       let(:slug) { 'cloudfoundry/bosh' }
       it { expect(queue).to eq 'builds.cloudfoundry' }
+    end
+
+    describe 'by multiple owners' do
+      let(:slug) { 'bar/foobar' }
+      it { expect(queue).to eq 'builds.multi-owner' }
     end
   end
 


### PR DESCRIPTION
This allows you to route multiple owners to a single queue without having to define multiple a queue definition for each owner.