### PR TITLE
Deprioritize jobs which are allowed to fail

### DIFF
--- a/lib/travis/scheduler/service/enqueue_owners.rb
+++ b/lib/travis/scheduler/service/enqueue_owners.rb
@@ -38,7 +38,7 @@ module Travis
           end
 
           def enqueue
-            jobs.each { |job| inline :enqueue_job, job, jid: jid }
+            jobs.partition { |job| !job.allow_failure }.flatten.each { |job| inline :enqueue_job, job, jid: jid }
           end
           time :enqueue
 


### PR DESCRIPTION
In other words, enqueue jobs which are not allowed to fail first before those which are.

This is not perfect, as there are multiple threads enqueuing the jobs, but it should be good enough for a lot of cases.