### PR TITLE
Put oauth_token only when config demands it

### DIFF
--- a/lib/travis/scheduler/serialize/worker.rb
+++ b/lib/travis/scheduler/serialize/worker.rb
@@ -11,7 +11,7 @@ module Travis
         require 'travis/scheduler/serialize/worker/ssh_key'
 
         def data
-          {
+          value = {
             type: :test,
             vm_type: repo.vm_type,
             queue: job.queue,
@@ -23,8 +23,9 @@ module Travis
             ssh_key: ssh_key,
             timeouts: repo.timeouts,
             cache_settings: cache_settings,
-            oauth_token: github_oauth_token
           }
+          value[:oauth_token] = github_oauth_token if Travis.config.prefer_https?
+          value
         end
 
         private

--- a/spec/travis/scheduler/serialize/worker_spec.rb
+++ b/spec/travis/scheduler/serialize/worker_spec.rb
@@ -89,8 +89,7 @@ describe Travis::Scheduler::Serialize::Worker do
           hard_limit: 180 * 60, # worker handles timeouts in seconds
           log_silence: 20 * 60
         },
-        cache_settings: s3,
-        oauth_token: 'token'
+        cache_settings: s3
       )
     end
 
@@ -246,8 +245,7 @@ describe Travis::Scheduler::Serialize::Worker do
           hard_limit: 180 * 60, # worker handles timeouts in seconds
           log_silence: 20 * 60
         },
-        cache_settings: s3,
-        oauth_token: 'token'
+        cache_settings: s3
       )
     end
 


### PR DESCRIPTION
This is a follow-up PR to https://github.com/travis-ci/travis-scheduler/pull/53, which put the token regardless of the setting. 