### PR TITLE
Add a minimal by_queue limit

### DIFF
--- a/lib/travis/queue/matcher.rb
+++ b/lib/travis/queue/matcher.rb
@@ -65,7 +65,7 @@ module Travis
 
         def check_unknown_matchers(used)
           unknown = used - KEYS
-          logger.warn MSGS[:unknown_matchers] % [name, unknown, repo.slug] if unknown.any?
+          logger.warn MSGS[:unknown_matchers] % [name, unknown, repo.slug] if logger && unknown.any?
         end
     end
   end

--- a/lib/travis/scheduler/limit/by_owner.rb
+++ b/lib/travis/scheduler/limit/by_owner.rb
@@ -5,7 +5,7 @@ require 'travis/scheduler/model/trial'
 module Travis
   module Scheduler
     module Limit
-      class ByOwner < Struct.new(:context, :owners, :job, :queued, :state, :config)
+      class ByOwner < Struct.new(:context, :owners, :job, :selected, :state, :config)
         include Helper::Context
 
         KEYS = [:by_boost, :by_config, :by_plan, :by_trial, :default]
@@ -21,7 +21,7 @@ module Travis
         private
 
           def current
-            state.running_by_owners + queued
+            state.running_by_owners + selected.size
           end
 
           def max

--- a/lib/travis/scheduler/limit/by_queue.rb
+++ b/lib/travis/scheduler/limit/by_queue.rb
@@ -34,7 +34,7 @@ module Travis
           end
 
           def queue
-            job.queue ||= Queue.new(job, config, nil).select
+            job.queue ||= Queue.new(job, context.config, nil).select
           end
 
           def repo

--- a/lib/travis/scheduler/limit/by_queue.rb
+++ b/lib/travis/scheduler/limit/by_queue.rb
@@ -1,0 +1,56 @@
+require 'travis/scheduler/helper/context'
+require 'travis/scheduler/helper/logging'
+
+module Travis
+  module Scheduler
+    module Limit
+      class ByQueue < Struct.new(:context, :owners, :job, :selected, :state, :_)
+        include Helper::Context
+
+        def enqueue?
+          return true unless enabled?
+          return true unless queue == ENV['BY_QUEUE_NAME']
+          result = current < max
+          report(max) if result
+          result
+        end
+
+        def reports
+          @reports ||= []
+        end
+
+        private
+
+          def enabled?
+            config[owners.key]
+          end
+
+          def current
+            state.running_by_queue(job.queue) + selected.select { |j| j.queue == queue }.size
+          end
+
+          def max
+            config[owners.key].to_i
+          end
+
+          def queue
+            job.queue ||= Queue.new(job, config, nil).select
+          end
+
+          def repo
+            job.repository
+          end
+
+          def report(value)
+            reports << MSGS[:max] % [owners.to_s, "queue #{job.queue}", value]
+            value
+          end
+
+          # TODO make this a repo setting at some point?
+          def config
+            @config ||= ENV['BY_QUEUE_LIMIT'].to_s.split(',').map { |pair| pair.split('=') }.to_h
+          end
+      end
+    end
+  end
+end

--- a/lib/travis/scheduler/limit/by_repo.rb
+++ b/lib/travis/scheduler/limit/by_repo.rb
@@ -4,7 +4,7 @@ require 'travis/scheduler/helper/logging'
 module Travis
   module Scheduler
     module Limit
-      class ByRepo < Struct.new(:context, :owners, :job, :queued, :state, :config)
+      class ByRepo < Struct.new(:context, :owners, :job, :selected, :state, :config)
         include Helper::Context
 
         def enqueue?
@@ -28,7 +28,7 @@ module Travis
           end
 
           def current
-            state.running_by_repo(repo.id) + queued
+            state.running_by_repo(repo.id) + selected.select { |j| j.repository_id == repo.id }.size
           end
 
           def max

--- a/lib/travis/scheduler/limit/jobs.rb
+++ b/lib/travis/scheduler/limit/jobs.rb
@@ -28,8 +28,8 @@ module Travis
           @reports ||= []
         end
 
-        def jobs
-          @jobs ||= []
+        def selected
+          @selected ||= []
         end
 
         private
@@ -40,7 +40,7 @@ module Travis
               when :limited
                 break
               when true
-                jobs << job
+                selected << job
               end
             end
           end
@@ -62,11 +62,11 @@ module Travis
           end
 
           def limits_for(job)
-            LIMITS.map { |limit| limit.new(context, owners, job, jobs, state, config) }
+            LIMITS.map { |limit| limit.new(context, owners, job, selected, state, config) }
           end
 
           def summary
-            MSGS[:summary] % [owners.to_s, queueable.size, state.running_by_owners, jobs.size]
+            MSGS[:summary] % [owners.to_s, queueable.size, state.running_by_owners, selected.size]
           end
 
           def report(*reports)

--- a/lib/travis/scheduler/limit/jobs.rb
+++ b/lib/travis/scheduler/limit/jobs.rb
@@ -11,12 +11,13 @@ module Travis
 
       class Jobs < Struct.new(:context, :owners)
         require 'travis/scheduler/limit/by_owner'
+        require 'travis/scheduler/limit/by_queue'
         require 'travis/scheduler/limit/by_repo'
         require 'travis/scheduler/limit/state'
 
         include Helper::Context
 
-        LIMITS = [ByOwner, ByRepo]
+        LIMITS = [ByOwner, ByRepo, ByQueue]
 
         def run
           check_all
@@ -44,6 +45,10 @@ module Travis
             end
           end
 
+          def set_queue(job)
+            inline :set_queue, job
+          end
+
           def check(job)
             catch(:result) { enqueue?(job) }
           end
@@ -57,7 +62,7 @@ module Travis
           end
 
           def limits_for(job)
-            LIMITS.map { |limit| limit.new(context, owners, job, jobs.size, state, config) }
+            LIMITS.map { |limit| limit.new(context, owners, job, jobs, state, config) }
           end
 
           def summary

--- a/lib/travis/scheduler/limit/state.rb
+++ b/lib/travis/scheduler/limit/state.rb
@@ -9,7 +9,7 @@ module Travis
         def initialize(owners, config = {})
           @owners = owners
           @config = config
-          @count  = { repo: {} }
+          @count  = { repo: {}, queue: {} }
           @boosts = {}
         end
 
@@ -19,6 +19,10 @@ module Travis
 
         def running_by_repo(id)
           @count[:repo][id] ||= Job.by_repo(id).running.count
+        end
+
+        def running_by_queue(queue)
+          @count[:queue][queue] ||= Job.by_owners(owners.all).by_queue(queue).running.count
         end
 
         def boost_for(login)

--- a/lib/travis/scheduler/record/job.rb
+++ b/lib/travis/scheduler/record/job.rb
@@ -16,6 +16,10 @@ class Job < ActiveRecord::Base
       where(owned_by(owners))
     end
 
+    def by_queue(queue)
+      where(queue: queue)
+    end
+
     def owned_by(owners)
       owners.map { |o| owner_id.eq(o.id).and(owner_type.eq(o.class.name)) }.inject(&:or)
     end

--- a/spec/travis/scheduler/limit_spec.rb
+++ b/spec/travis/scheduler/limit_spec.rb
@@ -13,7 +13,7 @@ describe Travis::Scheduler::Limit::Jobs do
   before  { config.limit.trial = nil }
   before  { config.limit.default = 1 }
   before  { config.plans = { one: 1, seven: 7, ten: 10 } }
-  subject { limit.run; limit.jobs }
+  subject { limit.run; limit.selected }
 
   # TODO refactor signature
   def create_jobs(count, owner, state, repo = nil, queue = nil)

--- a/spec/travis/scheduler/service/notify_spec.rb
+++ b/spec/travis/scheduler/service/notify_spec.rb
@@ -18,7 +18,7 @@ describe Travis::Scheduler::Service::Notify do
 
   describe 'sets the queue' do
     let(:config) { { language: 'objective-c', os: 'osx', osx_image: 'xcode8', group: 'stable', dist: 'osx'} }
-    let(:job)    { FactoryGirl.create(:job, state: :queued, config: config, queued_at: Time.parse('2016-01-01T10:30:00Z')) }
+    let(:job)    { FactoryGirl.create(:job, state: :queued, config: config, queue: nil, queued_at: Time.parse('2016-01-01T10:30:00Z')) }
 
     before { context.config.queues = [{ queue: 'builds.mac_osx', os: 'osx' }] }
     before { service.run }


### PR DESCRIPTION
Triggered by severe queue time issues on support for larger orgs that have lots of OSX jobs clogging up even boosted concurrency.

Only accessible through an env var at the moment, as we haven't had any product discussion about this.