### PR TITLE
Move jwt key under the jwt-aware addons

### DIFF
--- a/lib/travis/scheduler/serialize/worker/config/addons.rb
+++ b/lib/travis/scheduler/serialize/worker/config/addons.rb
@@ -74,25 +74,10 @@ module Travis
             end
 
             def filter(name, config)
-              if safe?(name)
+              if safe?(name) || has_jwt_under?(name)
                 config
-              elsif jwt_aware?(name) && config.respond_to?(:key?) && config.key?(:jwt)
-                config
-              elsif jwt? && jwt_aware?(name)
-                strip_encrypted(config)
               else
                 nil
-              end
-            end
-
-            def strip_encrypted(config)
-              case config
-              when Hash
-                compact(config.map { |key, value| [key, encrypted?(value) ? nil : value] }).to_h
-              when Array
-                config.map { |config| strip_encrypted(config) }
-              else
-                config
               end
             end
 
@@ -110,10 +95,6 @@ module Travis
 
             def has_jwt_under?(name)
               jwt_aware?(name) && config[name.to_sym].respond_to?(:keys) && config[name.to_sym].keys.include?(:jwt)
-            end
-
-            def encrypted?(value)
-              value.is_a?(Hash) && value.keys.any? { |key| key == :secure }
             end
 
             def compact(hash)

--- a/lib/travis/scheduler/serialize/worker/config/addons.rb
+++ b/lib/travis/scheduler/serialize/worker/config/addons.rb
@@ -67,7 +67,7 @@ module Travis
               if jwt? && config.keys.any? {|key| jwt_aware?(key)}
                 # jwt key is in the wrong place
                 if config.key?(:sauce_connect)
-                  config[:sauce_connect] = { :jwt => config[:jwt] }
+                  config[:sauce_connect].merge!({ :jwt => config[:jwt] })
                 end
               end
               config.map { |key, value| [key, filter(key, value)] }.to_h

--- a/lib/travis/scheduler/serialize/worker/config/addons.rb
+++ b/lib/travis/scheduler/serialize/worker/config/addons.rb
@@ -82,7 +82,7 @@ module Travis
             end
 
             def safe?(name)
-              SAFE.include?(name.to_sym)
+              SAFE.include?(name)
             end
 
             def jwt?
@@ -90,11 +90,11 @@ module Travis
             end
 
             def jwt_aware?(name)
-              JWT_AWARE.include?(name.to_sym)
+              JWT_AWARE.include?(name)
             end
 
             def has_jwt_under?(name)
-              jwt_aware?(name) && config[name.to_sym].respond_to?(:keys) && config[name.to_sym].keys.include?(:jwt)
+              jwt_aware?(name) && config[name].respond_to?(:keys) && config[name].keys.include?(:jwt)
             end
 
             def compact(hash)

--- a/lib/travis/scheduler/serialize/worker/config/normalize.rb
+++ b/lib/travis/scheduler/serialize/worker/config/normalize.rb
@@ -19,6 +19,10 @@ module Travis
               ssh_known_hosts
             ).freeze
 
+            JWT_AWARE = %i(
+              sauce_connect
+            )
+
             attr_reader :config, :options
 
             def initialize(config, options)
@@ -35,7 +39,7 @@ module Travis
             end
 
             def jwt_sanitize
-              if config && config.fetch(:addons,{}).key?(:jwt)
+              if config && (config.fetch(:addons,{}).key?(:jwt) || JWT_AWARE.any? { |addon| config.fetch(:addons, {}).key?(addon) })
                 config[:addons] = Addons.new(config[:addons]).jwt_sanitize
               end
               config

--- a/spec/travis/scheduler/serialize/worker/config_spec.rb
+++ b/spec/travis/scheduler/serialize/worker/config_spec.rb
@@ -128,6 +128,22 @@ describe Travis::Scheduler::Serialize::Worker::Config do
       let(:config) { { addons: { jwt: encrypt(var) } } }
       it { should eql(addons: { jwt: Array(var) }) }
     end
+
+    describe 'sauce_connect addon with jwt underneath' do
+      let(:var)    { 'SAUCE_ACCESS_KEY=foo012345678901234565789' }
+      let(:config) { { addons: { sauce_connect: { jwt: encrypt(var) } } } }
+
+      it "decrypts secret" do
+        should eq(addons: { sauce_connect: { jwt: var } })
+      end
+    end
+
+    describe 'jwt encrypted env var + sauce_connect addon with jwt underneath' do
+      let(:var)    { 'SAUCE_ACCESS_KEY=foo012345678901234565789' }
+      let(:config) { { addons: { sauce_connect: { jwt: encrypt(var) }, jwt: encrypt(var) } } }
+
+      it { should eq(addons: { sauce_connect: { jwt: var } , jwt: Array(var) } ) }
+    end
   end
 
   describe 'with full_addons being true' do

--- a/spec/travis/scheduler/serialize/worker/config_spec.rb
+++ b/spec/travis/scheduler/serialize/worker/config_spec.rb
@@ -129,12 +129,21 @@ describe Travis::Scheduler::Serialize::Worker::Config do
       it { should eql(addons: { jwt: Array(var) }) }
     end
 
-    describe 'sauce_connect addon with jwt underneath' do
+    context 'sauce_connect addon with jwt underneath' do
       let(:var)    { 'SAUCE_ACCESS_KEY=foo012345678901234565789' }
       let(:config) { { addons: { sauce_connect: { jwt: encrypt(var) } } } }
 
       it "decrypts secret" do
         should eq(addons: { sauce_connect: { jwt: var } })
+      end
+
+      context "with short secret" do
+        let(:var) { 'SAUCE_ACCESS_KEY=veryshort' }
+        let(:config) { { addons: { sauce_connect: { jwt: encrypt(var) } } } }
+
+        it "drops sauce_connect" do
+          should eq(addons: {})
+        end
       end
     end
 

--- a/spec/travis/scheduler/serialize/worker/config_spec.rb
+++ b/spec/travis/scheduler/serialize/worker/config_spec.rb
@@ -140,9 +140,9 @@ describe Travis::Scheduler::Serialize::Worker::Config do
 
     describe 'jwt encrypted env var + sauce_connect addon with jwt underneath' do
       let(:var)    { 'SAUCE_ACCESS_KEY=foo012345678901234565789' }
-      let(:config) { { addons: { sauce_connect: { jwt: encrypt(var) }, jwt: encrypt(var) } } }
+      let(:config) { { addons: { sauce_connect: { username: 'user1', jwt: encrypt(var) }, jwt: encrypt(var) } } }
 
-      it { should eq(addons: { sauce_connect: { jwt: var } , jwt: Array(var) } ) }
+      it { should eq(addons: { sauce_connect: { username: 'user1', jwt: var } , jwt: Array(var) } ) }
     end
   end
 


### PR DESCRIPTION
In addition to

```yaml
addons:
  sauce_connect:
    ⋮
  jwt:
    secure: …
```

also allow

```yaml
addons:
  sauce_connect:
    jwt:
      secure: …
```

Then pass it downstream.

If jwt definition is given both ways, keep both.

The intention here is that, by keeping both, we allow a gradual
transition to the latter.
When `travis-build` sees the old-style configuration and display
a deprecation warning, and stop processing at some point in
the future, say, a month's time.