### PR TITLE
Refactor ByStage job sorting

### DIFF
--- a/lib/travis/scheduler/limit/by_stage.rb
+++ b/lib/travis/scheduler/limit/by_stage.rb
@@ -32,8 +32,9 @@ module Travis
           def jobs
             @jobs ||= begin
               # TODO would it make sense to cache these on `state`?
-              jobs = Job.where(source_id: job.source_id)
-              sort(jobs).map { |job| attrs(job) }
+              Job.where(source_id: job.source_id)
+                .sort_by(&:stage_number_parts)
+                .map(&method(:attrs))
             end
           end
 
@@ -43,15 +44,6 @@ module Travis
               stage: job.stage_number,
               state: job.finished? ? :finished : :created
             }
-          end
-
-          def sort(jobs)
-            num = ->(job) { job.stage_number.split('.').map(&:to_i) }
-            jobs.sort { |lft, rgt| num.(lft) <=> num.(rgt) }
-          end
-
-          def stages
-            jobs.map { |job| job[:stage] }
           end
 
           def report

--- a/lib/travis/scheduler/record/job.rb
+++ b/lib/travis/scheduler/record/job.rb
@@ -57,6 +57,10 @@ class Job < ActiveRecord::Base
     FINISHED_STATES.include?(state.try(:to_sym))
   end
 
+  def stage_number_parts
+    stage_number.split('.').map(&:to_i)
+  end
+
   def queueable=(value)
     if value
       queueable || create_queueable

--- a/spec/travis/scheduler/record/job_spec.rb
+++ b/spec/travis/scheduler/record/job_spec.rb
@@ -1,8 +1,12 @@
 describe Job do
   let(:config) { { rvm: '1.8.7' } }
-  let(:job) { FactoryGirl.create(:job, config: config).reload }
+  let(:job) { FactoryGirl.create(:job, config: config, stage_number: '1.2').reload }
 
   it 'deserializes config' do
     expect(job.config).to be_a(Hash)
+  end
+
+  it 'renders its stage number numeric parts' do
+    expect(job.stage_number_parts).to eq [1, 2]
   end
 end


### PR DESCRIPTION
I absolutely love [Sven’s tweet](https://twitter.com/svenfuchs/status/865490046572417024), but a month later I still can’t get over that sorting in #80 – hence this. :trollface: 

I have no idea how to run the tests – bundling locally blows up with `Authentication is required for gems.contribsys.com`, as does [building on Travis](https://travis-ci.org/chastell/travis-scheduler/builds/243945725) – so this is all written in the dark; all I know is this passes the `ruby -c` syntax check. :wink: 

`Scheduler::Limit::ByStage#stages` seems unused, so I dropped it along the way.