### PR TITLE
Support queue config via generic env vars

### DIFF
--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -17,6 +17,7 @@ module Travis
              metrics:    { reporter: 'librato' },
              plans:      { },
              queue:      { default: 'builds.gce', redirect: {} },
+             queues:     [ queue: 'name', os: 'os', dist: 'dist', group: 'group', sudo: false, osx_image: 'osx_image', language: 'language', owner: 'owner', slug: 'slug'],
              redis:      { url: 'redis://localhost:6379' },
              sentry:     { },
              sidekiq:    { namespace: 'sidekiq', pool_size: 3, log_level: :warn },

--- a/spec/travis/scheduler/config_spec.rb
+++ b/spec/travis/scheduler/config_spec.rb
@@ -12,4 +12,32 @@ describe Travis::Scheduler::Config do
 
     it { should eq :debug }
   end
+
+  describe 'queues' do
+    env TRAVIS_QUEUES_0_QUEUE: 'builds.gce',
+        TRAVIS_QUEUES_0_SUDO:  'true',
+        TRAVIS_QUEUES_0_GROUP: 'legacy',
+        TRAVIS_QUEUES_1_QUEUE: 'builds.gce',
+        TRAVIS_QUEUES_1_SUDO:  'true',
+        TRAVIS_QUEUES_2_QUEUE: 'builds.ec2',
+        TRAVIS_QUEUES_2_SUDO:  'false',
+        TRAVIS_QUEUES_2_DIST:  'trusty',
+        TRAVIS_QUEUES_3_QUEUE: 'builds.docker',
+        TRAVIS_QUEUES_3_SUDO:  'false',
+        TRAVIS_QUEUES_4_QUEUE: 'builds.gce',
+        TRAVIS_QUEUES_4_DIST:  'trusty'
+
+    it { expect(config.queues[0]).to eq queue: 'builds.gce', sudo: true, group: 'legacy' }
+    it { expect(config.queues[1]).to eq queue: 'builds.gce', sudo: true }
+    it { expect(config.queues[2]).to eq queue: 'builds.ec2', sudo: false, dist: 'trusty' }
+    it { expect(config.queues[3]).to eq queue: 'builds.docker', sudo: false }
+    it { expect(config.queues[4]).to eq queue: 'builds.gce', dist: 'trusty' }
+
+    describe 'with a nested array' do
+      env TRAVIS_QUEUES_0_QUEUE: 'builds.gce',
+          TRAVIS_QUEUES_0_SERVICES_0: 'docker'
+
+      xit { expect(config.queues[0]).to eq queue: 'builds.gce', services: ['docker'] }
+    end
+  end
 end


### PR DESCRIPTION
This enables using https://github.com/travis-ci/travis-config/blob/master/spec/travis/config/env_spec.rb#L71-L83 for queues config.

One thing that currently does not work is using an array such as `services: ['docker']` for selection, because of a bug in travis-config (which should be trivial to fix).