### PR TITLE
Send `user_ids` along with pusher message if user-channel enabled

### DIFF
--- a/lib/travis/scheduler/service/notify.rb
+++ b/lib/travis/scheduler/service/notify.rb
@@ -45,7 +45,7 @@ module Travis
           end
 
           def notify_live
-            Live.push(live_payload, event: 'job:queued')
+            Live.push(live_payload, live_params)
           end
 
           def rollout?
@@ -61,6 +61,20 @@ module Travis
             Serialize::Live.new(job).data
           end
           time :live_payload
+
+          def live_params
+            params = { event: 'job:queued' }
+            uid = "#{job.repository.owner_id}-#{job.repository.owner_type[0]}"
+            if Rollout.matches?('user-channel', redis: redis, uid: uid)
+              params[:user_ids] = user_ids
+            end
+            params
+          end
+          time :live_params
+
+          def user_ids
+            job.repository.permissions.pluck(:user_id)
+          end
 
           def owner
             job.owner

--- a/spec/travis/scheduler/service/notify_spec.rb
+++ b/spec/travis/scheduler/service/notify_spec.rb
@@ -144,6 +144,19 @@ describe Travis::Scheduler::Service::Notify do
     service.run
   end
 
+  context 'when user channel is enabled' do
+    before do
+      context.redis.set('user-channel.rollout.enabled', '1')
+      uid = "#{job.repository.owner_id}-#{job.repository.owner_type[0]}"
+      context.redis.sadd('user-channel.rollout.uids', uid)
+    end
+
+    it 'publishes to live' do
+      live.expects(:push).with(instance_of(Hash), event: 'job:queued', user_ids: job.repository.permissions.pluck(:user_id))
+      service.run
+    end
+  end
+
   describe 'sets the queue' do
     let(:config) { { language: 'objective-c', os: 'osx', osx_image: 'xcode8', group: 'stable', dist: 'osx'} }
     let(:job)    { FactoryGirl.create(:job, state: :queued, config: config, queue: nil, queued_at: Time.parse('2016-01-01T10:30:00Z')) }


### PR DESCRIPTION
This will allow us to switch to per-user channels instaed of
per-repo channels