### PR TITLE
First stab at a merged limit strategy

### DIFF
--- a/lib/travis/owners/group.rb
+++ b/lib/travis/owners/group.rb
@@ -27,10 +27,6 @@ module Travis
         subscriptions.subscribers
       end
 
-      def merge_mode?
-        any? { |owner| Features.owner_active?(:merge_mode, owner) }
-      end
-
       def ==(other)
         key == other.key
       end

--- a/lib/travis/owners/group.rb
+++ b/lib/travis/owners/group.rb
@@ -1,6 +1,12 @@
 module Travis
   module Owners
     class Group < Struct.new(:all, :config)
+      include Enumerable
+
+      def each(&block)
+        all.each(&block)
+      end
+
       def key
         logins.join(':')
       end
@@ -19,6 +25,10 @@ module Travis
 
       def subscribed_owners
         subscriptions.subscribers
+      end
+
+      def merge_mode?
+        any? { |owner| Features.owner_active?(:merge_mode, owner) }
       end
 
       def ==(other)

--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -10,7 +10,7 @@ module Travis
              enterprise: false,
              github:     { api_url: 'https://api.github.com', source_host: 'github.com' },
              interval:   2,
-             limit:      { default: 5, by_owner: {}, delegate: {} },
+             limit:      { public: 5, default: 5, by_owner: {}, delegate: {} },
              lock:       { strategy: :redis, ttl: 150 },
              logger:     { time_format: false, process_id: false, thread_id: false },
              log_level:  :info,

--- a/lib/travis/scheduler/limit/by_owner.rb
+++ b/lib/travis/scheduler/limit/by_owner.rb
@@ -85,7 +85,7 @@ module Travis
           end
 
           def merge_mode?
-            owners.merge_mode?
+            owners.any? { |owner| Rollout.matches?(:merge, owner: owner.login, redis: context.redis) }
           end
 
           def trial

--- a/lib/travis/scheduler/limit/by_public.rb
+++ b/lib/travis/scheduler/limit/by_public.rb
@@ -1,0 +1,42 @@
+require 'travis/scheduler/helper/context'
+require 'travis/scheduler/helper/logging'
+require 'travis/scheduler/model/trial'
+
+module Travis
+  module Scheduler
+    module Limit
+      class ByPublic < Struct.new(:context, :owners, :job, :selected, :state, :config)
+        include Helper::Context
+
+        def enqueue?
+          p [:public, job.id, current, max, job.public?, current < max]
+          current < max if job.public? && owners.merge_mode?
+        end
+
+        def reports
+          @reports ||= []
+        end
+
+        private
+
+          def current
+            state.running_by_owners_public + selected.select(&:public?).size
+          end
+
+          def max
+            config[:limit][:public] || 5
+          end
+
+          def report(key, value)
+            key  = key.to_s.sub('by_', '').to_sym
+            name = [job.owner.is_a?(User) ? 'user' : 'org', job.owner.login].join(' ')
+            args = [name, key, value]
+            args << owners.subscribed_owners.join(', ') if key == :plan
+            msg  = MSGS[:"max_#{key}"] || MSGS[:max]
+            reports << msg % args
+            value
+          end
+      end
+    end
+  end
+end

--- a/lib/travis/scheduler/limit/jobs.rb
+++ b/lib/travis/scheduler/limit/jobs.rb
@@ -12,6 +12,7 @@ module Travis
       }
 
       class Jobs < Struct.new(:context, :owners)
+        require 'travis/scheduler/limit/by_public'
         require 'travis/scheduler/limit/by_owner'
         require 'travis/scheduler/limit/by_queue'
         require 'travis/scheduler/limit/by_repo'

--- a/lib/travis/scheduler/limit/state.rb
+++ b/lib/travis/scheduler/limit/state.rb
@@ -14,7 +14,11 @@ module Travis
         end
 
         def running_by_owners
-          @count[:owners] ||= Job.by_owners(owners.all).running.count
+          @count[:owners] ||= running_jobs_by_owners.count
+        end
+
+        def running_by_owners_public
+          @count[:public] ||= running_jobs_by_owners.where(private: false).count
         end
 
         def running_by_repo(id)
@@ -28,6 +32,12 @@ module Travis
         def boost_for(login)
           @boosts[login] ||= Scheduler.redis.get(BOOST % login).to_i
         end
+
+        private
+
+          def running_jobs_by_owners
+            @running_jobs_by_owners ||= Job.by_owners(owners.all).running
+          end
       end
     end
   end

--- a/lib/travis/scheduler/record/job.rb
+++ b/lib/travis/scheduler/record/job.rb
@@ -64,4 +64,8 @@ class Job < ActiveRecord::Base
       Queueable.where(job_id: id).delete_all
     end
   end
+
+  def public?
+    !private?
+  end
 end

--- a/spec/travis/scheduler/limit_spec.rb
+++ b/spec/travis/scheduler/limit_spec.rb
@@ -2,7 +2,7 @@ describe Travis::Scheduler::Limit::Jobs do
   let(:org)     { FactoryGirl.create(:org, login: 'travis-ci') }
   let(:repo)    { FactoryGirl.create(:repo, owner: owner) }
   let(:build)   { FactoryGirl.create(:build) }
-  let(:owner)   { FactoryGirl.create(:user) }
+  let(:owner)   { FactoryGirl.create(:user, login: 'svenfuchs') }
   let(:owners)  { Travis::Owners.group(data, config.to_h) }
   let(:context) { Travis::Scheduler.context }
   let(:redis)   { context.redis }
@@ -205,10 +205,7 @@ describe Travis::Scheduler::Limit::Jobs do
   end
 
   describe 'The Merge mode' do
-    let(:features) { Travis::Features }
-
-    before { features.activate_owner(:merge_mode, owner) }
-    after  { features.deactivate_owner(:merge_mode, owner) }
+    env ROLLOUT: 'merge', ROLLOUT_MERGE_OWNERS: 'svenfuchs'
 
     before { config.limit.public  = 3 } # we allow up to 3 extra public jobs
     before { config.limit.default = 1 } # we allow 1 public or private job by default

--- a/spec/travis/scheduler/limit_spec.rb
+++ b/spec/travis/scheduler/limit_spec.rb
@@ -15,17 +15,17 @@ describe Travis::Scheduler::Limit::Jobs do
 
   before  { config.limit.trial = nil }
   before  { config.limit.default = 1 }
-  before  { config.plans = { one: 1, seven: 7, ten: 10 } }
+  before  { config.plans = { one: 1, two: 2, seven: 7, ten: 10 } }
   subject { limit.run; limit.selected }
 
   def create_jobs(count, attrs = {})
-    # owner, state, queueable = nil, repo = nil, queue = nil, stage_number = nil, stage = nil
     defaults = {
       repository: repo,
       owner: owner,
       source: build,
       state: :created,
-      queueable: true
+      queueable: true,
+      private: false
     }
     1.upto(count) { FactoryGirl.create(:job, defaults.merge(attrs)) }
   end
@@ -201,6 +201,85 @@ describe Travis::Scheduler::Limit::Jobs do
       before { one.jobs.update_all(state: :passed) }
       before { Queueable.where(job_id: one.jobs.pluck(:id)).delete_all }
       it { expect(subject.first.stage_number).to eq '2.1' }
+    end
+  end
+
+  describe 'The Merge mode' do
+    let(:features) { Travis::Features }
+
+    before { features.activate_owner(:merge_mode, owner) }
+    after  { features.deactivate_owner(:merge_mode, owner) }
+
+    before { config.limit.public  = 3 } # we allow up to 3 extra public jobs
+    before { config.limit.default = 1 } # we allow 1 public or private job by default
+
+    describe 'no running jobs, 2 public, 2 private, and 2 public jobs waiting, no subscription' do
+      before { create_jobs(2, private: false) }
+      before { create_jobs(2, private: true) }
+      before { create_jobs(2, private: false) }
+
+      it { expect(subject.size).to eq 4 }
+      it { expect(subject.map(&:public?)).to eq [true, true, false, true] }
+    end
+
+    describe 'no running jobs, 2 public and 4 private jobs waiting, no subscription' do
+      before { create_jobs(2, private: false) }
+      before { create_jobs(4, private: true) }
+
+      it { expect(subject.size).to eq 3 }
+      it { expect(subject.map(&:public?)).to eq [true, true, false] }
+    end
+
+    describe 'no running jobs, 4 public and 4 private jobs waiting, no subscription' do
+      before { create_jobs(4, private: false) }
+      before { create_jobs(4, private: true) }
+
+      it { expect(subject.size).to eq 4 }
+      it { expect(subject.map(&:public?)).to eq [true, true, true, true] }
+    end
+
+    describe 'no running jobs, 4 private and 4 public jobs waiting, no subscription' do
+      before { create_jobs(4, private: true) }
+      before { create_jobs(4, private: false) }
+
+      it { expect(subject.size).to eq 4 }
+      it { expect(subject.map(&:public?)).to eq [false, true, true, true] }
+    end
+
+    describe 'no running jobs, 4 private and 4 public jobs waiting, two jobs subscription' do
+      before { FactoryGirl.create(:subscription, selected_plan: :two, valid_to: Time.now.utc, owner_type: owner.class.name, owner_id: owner.id) }
+      before { create_jobs(4, private: true) }
+      before { create_jobs(4, private: false) }
+
+      it { expect(subject.size).to eq 5 }
+      it { expect(subject.map(&:public?)).to eq [false, false, true, true, true] }
+    end
+
+    describe '2 running public jobs, 2 public and 2 private jobs waiting, no subscription' do
+      before { create_jobs(2, private: false, state: :started) }
+      before { create_jobs(2, private: false) }
+      before { create_jobs(2, private: true) }
+
+      it { expect(subject.size).to eq 2 }
+      it { expect(subject.map(&:public?)).to eq [true, true] }
+    end
+
+    describe '1 running private job, 2 public and 2 private jobs waiting, no subscription' do
+      before { create_jobs(1, private: true, state: :started) }
+      before { create_jobs(2, private: false) }
+      before { create_jobs(2, private: true) }
+
+      it { expect(subject.size).to eq 2 }
+      it { expect(subject.map(&:public?)).to eq [true, true] }
+    end
+
+    describe '1 running private job, 2 private and 2 public jobs waiting, no subscription' do
+      before { create_jobs(1, private: true, state: :started) }
+      before { create_jobs(2, private: true) }
+      before { create_jobs(2, private: false) }
+
+      it { expect(subject.size).to eq 2 }
+      it { expect(subject.map(&:public?)).to eq [true, true] }
     end
   end
 end


### PR DESCRIPTION
This is a pretty hack'ish solution to the problem, and we'd definitely want to get back to this with a refactoring.

Issues with the current implementation/design:

* `Limit::Jobs` implements an `AND` relation for all `Limit` strategies: https://github.com/travis-ci/travis-scheduler/blob/master/lib/travis/scheduler/limit/jobs.rb#L84
* `Limit::ByOwner` internally implements an `OR` relation (by the way of picking the first value it finds): https://github.com/travis-ci/travis-scheduler/blob/master/lib/travis/scheduler/limit/by_owner.rb#L30

... so the new logic has to go *into* `Limit::ByOwner`, which is designed/meant for having a single max value, and a single current value.