### PR TITLE
Add script/generate-job-payload.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp
 /coverage
 .env
 NOTES.md
+.envrc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/travis-exceptions
-  revision: 71b11939f1f3b86d1e2fd94f3b9b8f78af290e12
+  revision: ab236981f810b820bc3ebfaf33f317bbaa9b3465
   specs:
     travis-exceptions (0.0.2)
       sentry-raven

--- a/script/generate-job-payload.rb
+++ b/script/generate-job-payload.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# This script takes a job id and spits out the job payload for that id
+# Usage:
+#`heroku run -a travis-scheduler-<stage> script/generate-job-payload <job ID>`
+
+$: << 'lib'
+require 'bundler/setup'
+require 'travis/scheduler'
+
+# Silence Raven so output can be piped directly elsewhere.
+Travis::Scheduler.logger = Logger.new(IO::NULL)
+
+require 'raven/logger'
+module Raven
+  class Logger
+    def add(*)
+    end
+  end
+end
+
+Travis::Scheduler.setup
+
+id = Integer(ARGV[0])
+job = Job.find(id)
+config = Travis::Scheduler::Config.load
+payload = Travis::Scheduler::Serialize::Worker.new(job, config).data
+puts JSON.generate(payload)


### PR DESCRIPTION
The addition of `script/generate-job-payload.rb` permits retrieving the JSON representation of a given job:

```
$ heroku run -a travis-scheduler-staging script/generate-job-payload.rb 615732
Running script/generate-job-payload.rb 615732 on ⬢ travis-scheduler-staging... up, run.1626 (Hobby)
[...]
{"type":"test","vm_type":"default","queue":"builds.ec2","config":{"language":"ruby","sudo":false,"install":true,"script":["cat ~/build.sh"],"notifications":{"email":false,"slack":{"rooms":[{"secure":"woohoo/lallaa++fanko+blah/asefasf+mojitbit="}],"template":["Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository}@%{branch} by %{author} %{result} in %{duration} (elapsed time: %{elapsed_time}) subject: %{commit_subject} message: %{commit_message}"]}},".result":"configured","group":"stable","dist":"trusty","os":"linux","addons":{"deploy":[{"provider":"script","edge":{"source":"travis-ci/dpl"},"script":"echo \"foos\""},{"provider":"script","edge":{"source":"travis-ci/dpl"},"script":"echo \"bar\""}]}},"env_vars":[],"job":{"id":615732,"number":"549.1","commit":"66d790412d3a38896654a32aded15aafeb3216e4","commit_range":"5e46ee30bf38da0a3ed060270dedda91e0a69436...66d790412d3a38896654a32aded15aafeb3216e4","commit_message":"Update .travis.yml","branch":"foo-patch-3","ref":null,"tag":null,"pull_request":false,"state":"passed","secure_env_enabled":true,"secure_env_removed":false,"debug_options":{},"queued_at":"2017-08-11T12:03:20Z","allow_failure":false},"source":{"id":615731,"number":"549","event_type":"cron"},"repository":{"id":49315,"github_id":68009876,"slug":"travis-testing-org-1/travis_staging_test","source_url":"https://github.com/travis-testing-org-1/travis_staging_test.git","api_url":"https://api.github.com/repos/travis-testing-org-1/travis_staging_test","last_build_id":615731,"last_build_number":"549","last_build_started_at":"2017-08-11T12:03:17Z","last_build_finished_at":"2017-08-11T12:03:53Z","last_build_duration":36,"last_build_state":"passed","default_branch":"master","description":"Test repo for testing travis staging"},"ssh_key":null,"timeouts":{"hard_limit":null,"log_silence":null},"cache_settings":{"fetch_timeout":1200,"push_timeout":7200,"s3":{"access_key_id":"YADDAYADDA","aws_signature_version":"4","bucket":"travis-cache-staging-org","hostname":"s3.amazonaws.com","secret_access_key":"yaddayadda"},"type":"s3"}}
```


This can be fed directly to `travis-build`, for example (be sure to specify the `application/json` Content-Type header):

```
curl -X POST localhost:4000/script \
    -H "Content-Type: application/json" \
    --data "$(heroku run -a travis-scheduler-staging script/generate-job-payload.rb 615732)" 
```
^ This will output `build.sh`-like contents.

Thank you @igorwwwwwwwwwwwwwwwwwwww for your work on this!