### PR TITLE
Allow setting a global default for the by_queue limit

### DIFF
--- a/lib/travis/scheduler/limit/by_queue.rb
+++ b/lib/travis/scheduler/limit/by_queue.rb
@@ -8,7 +8,6 @@ module Travis
         include Helper::Context
 
         def enqueue?
-          return true unless enabled?
           return true unless queue == ENV['BY_QUEUE_NAME']
           result = current < max
           report(max) if result
@@ -21,16 +20,12 @@ module Travis
 
         private
 
-          def enabled?
-            config[owners.key]
-          end
-
           def current
             state.running_by_queue(job.queue) + selected.select { |j| j.queue == queue }.size
           end
 
           def max
-            config[owners.key].to_i
+            config.fetch(owners.key, default).to_i
           end
 
           def queue
@@ -44,6 +39,10 @@ module Travis
           def report(value)
             reports << MSGS[:max] % [owners.to_s, "queue #{job.queue}", value]
             value
+          end
+
+          def default
+            ENV.fetch('BY_QUEUE_DEFAULT', 2).to_i
           end
 
           # TODO make this a repo setting at some point?

--- a/spec/travis/scheduler/limit_spec.rb
+++ b/spec/travis/scheduler/limit_spec.rb
@@ -116,7 +116,32 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(report).to include('user svenfuchs: total: 7, running: 3, queueable: 2') }
   end
 
-  describe 'with a by_queue limit of 2' do
+  describe 'with no by_queue config being given' do
+    before { create_jobs(9, queue: 'builds.osx') }
+    before { create_jobs(1, queue: 'builds.docker') }
+    before { config.limit.default = 99 }
+    before { subject }
+
+    it { expect(subject.size).to eq 10 }
+    it { expect(report).to include('user svenfuchs: total: 10, running: 0, queueable: 10') }
+  end
+
+  describe 'with a default by_queue limit of 2' do
+    before { create_jobs(9, queue: 'builds.osx') }
+    before { create_jobs(1, queue: 'builds.docker') }
+    before { config.limit.default = 99 }
+    before { ENV['BY_QUEUE_DEFAULT'] = '2' }
+    before { ENV['BY_QUEUE_NAME'] = 'builds.osx' }
+    after  { ENV.delete('BY_QUEUE_LIMIT') }
+    after  { ENV.delete('BY_QUEUE_NAME') }
+    before { subject }
+
+    it { expect(subject.size).to eq 3 }
+    it { expect(report).to include('max jobs for user svenfuchs by queue builds.osx: 2') }
+    it { expect(report).to include('user svenfuchs: total: 10, running: 0, queueable: 3') }
+  end
+
+  describe 'with a by_queue limit of 2 for the owner' do
     before { create_jobs(9, queue: 'builds.osx') }
     before { create_jobs(1, queue: 'builds.docker') }
     before { config.limit.default = 99 }
@@ -131,7 +156,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(report).to include('user svenfuchs: total: 10, running: 0, queueable: 3') }
   end
 
-  describe 'with a by_queue limit of 2 and a repo limit of 3 on another repo' do
+  describe 'with a by_queue limit of 2 for the owner and a repo limit of 3 on another repo' do
     let(:other) { FactoryGirl.create(:repo, github_id: 2) }
     before { create_jobs(9, repository: repo, queue: 'builds.osx') }
     before { create_jobs(5, repository: other, queue: 'builds.docker') }
@@ -148,7 +173,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(report).to include('user svenfuchs: total: 14, running: 0, queueable: 5') }
   end
 
-  describe 'with a by_queue limit and jobs created for a different queue' do
+  describe 'with a by_queue limit for the owner and jobs created for a different queue' do
     before { create_jobs(9, queue: 'builds.docker') }
     before { create_jobs(1, queue: 'builds.osx') }
     before { config.limit.default = 5 }


### PR DESCRIPTION
```
# config:
BY_QUEUE_DEFAULT:             1
BY_QUEUE_NAME:                builds.ec2

# log
 I c19e6f Evaluating jobs for owner group: user svenfuchs
 I c19e6f max jobs for user svenfuchs by default: 5
 I c19e6f max jobs for user svenfuchs by queue builds.ec2: 1
 I c19e6f user svenfuchs: total: 4, running: 0, queueable: 1
 I c19e6f enqueueing job 628222 (svenfuchs/test-2)
 I c19e6f Setting queue to builds.ec2 for job=628222
```