### PR TITLE
Use Sidekiq's super_fetch! method

### DIFF
--- a/lib/travis/scheduler/support/sidekiq.rb
+++ b/lib/travis/scheduler/support/sidekiq.rb
@@ -25,7 +25,7 @@ module Travis
             c.logger.level = ::Logger::const_get(config.sidekiq.log_level.upcase.to_s)
 
             if pro?
-              c.reliable_fetch!
+              c.super_fetch!
               c.reliable_scheduler!
             end
           end


### PR DESCRIPTION
From commit message:

```
Sidekiq Pro introduces algorithms to work more reliably than the regular
version. Till now we use the one called `reliable_fetch!`. It's
deprecated and it will be removed in next major version and
`super_fetch!` is now recommended way.
```

More info here: https://github.com/mperham/sidekiq/wiki/Reliability