### PR TITLE
[WIP] Use Subscription concurrency field

### DIFF
--- a/lib/travis/owners/subscriptions.rb
+++ b/lib/travis/owners/subscriptions.rb
@@ -6,7 +6,7 @@ module Travis
       end
 
       def max_jobs
-        @max_jobs ||= plan_limits.inject(&:+).to_i
+        @max_jobs ||= concurrencies.inject(&:+).to_i
       end
 
       def subscribers
@@ -15,16 +15,8 @@ module Travis
 
       private
 
-        def plan_limits
-          plans.map { |plan| plan_limit(plan) }.compact
-        end
-
-        def plan_limit(plan)
-          config[plan.to_sym]
-        end
-
-        def plans
-          subscriptions.map(&:selected_plan).compact
+        def concurrencies
+          subscriptions.map(&:concurrency).compact
         end
 
         def subscriptions

--- a/spec/travis/owners/subscriptions_spec.rb
+++ b/spec/travis/owners/subscriptions_spec.rb
@@ -11,7 +11,7 @@ describe Travis::Owners::Subscriptions do
   subject { described_class.new(owners, plans).max_jobs }
 
   describe 'a single org with a five jobs plan' do
-    before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five) }
+    before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five, concurrency: 5) }
     it { should eq 5 }
   end
 
@@ -19,24 +19,24 @@ describe Travis::Owners::Subscriptions do
     let(:limits) { { delegate: { sinatra: 'travis' } } }
 
     describe 'with a subscription on a delegatee' do
-      before { FactoryGirl.create(:subscription, owner: sinatra, selected_plan: :five) }
+      before { FactoryGirl.create(:subscription, owner: sinatra, selected_plan: :five, concurrency: 5) }
       it { should eq 5 }
     end
 
     describe 'with a subscription on a delegate' do
-      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five) }
+      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five, concurrency: 5) }
       it { should eq 5 }
     end
 
     describe 'with an invalid subscription on a delegatee' do
-      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five) }
+      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five, concurrency: 5) }
       before { FactoryGirl.create(:subscription, owner: sinatra) }
       it { should eq 5 }
     end
 
     describe 'with an invalid subscription on a delegate' do
       before { FactoryGirl.create(:subscription, owner: travis) }
-      before { FactoryGirl.create(:subscription, owner: sinatra, selected_plan: :five) }
+      before { FactoryGirl.create(:subscription, owner: sinatra, selected_plan: :five, concurrency: 5) }
       it { should eq 5 }
     end
   end

--- a/spec/travis/owners_spec.rb
+++ b/spec/travis/owners_spec.rb
@@ -15,18 +15,18 @@ describe Travis::Owners do
     end
 
     describe 'with a subscription on the delegatee' do
-      before { FactoryGirl.create(:subscription, owner: anja, selected_plan: :ten) }
+      before { FactoryGirl.create(:subscription, owner: anja, selected_plan: :ten, concurrency: 10) }
       it { expect(owners.max_jobs).to eq 10 }
     end
 
     describe 'with a subscription on the delegate' do
-      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :ten) }
+      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :ten, concurrency: 10) }
       it { expect(owners.max_jobs).to eq 10 }
     end
 
     describe 'with a subscription on both the delegatee and delegate' do
-      before { FactoryGirl.create(:subscription, owner: anja, selected_plan: :ten) }
-      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five) }
+      before { FactoryGirl.create(:subscription, owner: anja, selected_plan: :ten, concurrency: 10) }
+      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five, concurrency: 5) }
       it { expect(owners.max_jobs).to eq 15 }
     end
   end
@@ -37,18 +37,18 @@ describe Travis::Owners do
     end
 
     describe 'with a subscription on the delegatee' do
-      before { FactoryGirl.create(:subscription, owner: anja, selected_plan: :ten) }
+      before { FactoryGirl.create(:subscription, owner: anja, selected_plan: :ten, concurrency: 10) }
       it { expect(owners.subscribed_owners).to eq %w(anja) }
     end
 
     describe 'with a subscription on the delegate' do
-      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :ten) }
+      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :ten, concurrency: 10) }
       it { expect(owners.subscribed_owners).to eq %w(travis) }
     end
 
     describe 'with a subscription on both the delegatee and delegate' do
-      before { FactoryGirl.create(:subscription, owner: anja, selected_plan: :ten) }
-      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five) }
+      before { FactoryGirl.create(:subscription, owner: anja, selected_plan: :ten, concurrency: 10) }
+      before { FactoryGirl.create(:subscription, owner: travis, selected_plan: :five, concurrency: 5) }
       it { expect(owners.subscribed_owners).to eq %w(anja travis) }
     end
   end

--- a/spec/travis/scheduler/limit_spec.rb
+++ b/spec/travis/scheduler/limit_spec.rb
@@ -42,7 +42,7 @@ describe Travis::Scheduler::Limit::Jobs do
 
   describe 'with a subscription limit 1' do
     before { create_jobs(3) }
-    before { FactoryGirl.create(:subscription, valid_to: Time.now.utc, owner_type: owner.class.name, owner_id: owner.id, selected_plan: :one) }
+    before { FactoryGirl.create(:subscription, valid_to: Time.now.utc, owner_type: owner.class.name, owner_id: owner.id, selected_plan: :one, concurrency: 1) }
     before { subject }
 
     it { expect(subject.size).to eq 1 }
@@ -106,7 +106,7 @@ describe Travis::Scheduler::Limit::Jobs do
     before { config.limit.default = 1 }
     before { create_jobs(7, state: :created) }
     before { create_jobs(3, state: :started) }
-    before { FactoryGirl.create(:subscription, selected_plan: :seven, valid_to: Time.now.utc, owner_type: owner.class.name, owner_id: owner.id) }
+    before { FactoryGirl.create(:subscription, selected_plan: :seven, concurrency: 7, valid_to: Time.now.utc, owner_type: owner.class.name, owner_id: owner.id) }
     before { repo.settings.update_attributes!(maximum_number_of_builds: 5) }
     before { subject }
 
@@ -225,7 +225,7 @@ describe Travis::Scheduler::Limit::Jobs do
     before { config.limit.delegate = { owner.login => org.login, carla.login => org.login } }
 
     describe 'with one subscription' do
-      before { FactoryGirl.create(:subscription, selected_plan: :seven, valid_to: Time.now.utc, owner_type: org.class.name, owner_id: org.id) }
+      before { FactoryGirl.create(:subscription, selected_plan: :seven, concurrency: 7, valid_to: Time.now.utc, owner_type: org.class.name, owner_id: org.id) }
       before { subject }
 
       it { expect(subject.size).to eq 5 }
@@ -235,8 +235,8 @@ describe Travis::Scheduler::Limit::Jobs do
     end
 
     describe 'with multiple subscriptions' do
-      before { FactoryGirl.create(:subscription, selected_plan: :one, valid_to: Time.now.utc, owner_type: owner.class.name, owner_id: owner.id) }
-      before { FactoryGirl.create(:subscription, selected_plan: :seven, valid_to: Time.now.utc, owner_type: org.class.name, owner_id: org.id) }
+      before { FactoryGirl.create(:subscription, selected_plan: :one, concurrency: 1, valid_to: Time.now.utc, owner_type: owner.class.name, owner_id: owner.id) }
+      before { FactoryGirl.create(:subscription, selected_plan: :seven, concurrency: 7, valid_to: Time.now.utc, owner_type: org.class.name, owner_id: org.id) }
       before { subject }
 
       it { expect(subject.size).to eq 6 }
@@ -310,7 +310,7 @@ describe Travis::Scheduler::Limit::Jobs do
     end
 
     describe 'no running jobs, 4 private and 4 public jobs waiting, two jobs subscription' do
-      before { FactoryGirl.create(:subscription, selected_plan: :two, valid_to: Time.now.utc, owner_type: owner.class.name, owner_id: owner.id) }
+      before { FactoryGirl.create(:subscription, selected_plan: :two, concurrency: 2, valid_to: Time.now.utc, owner_type: owner.class.name, owner_id: owner.id) }
       before { create_jobs(4, private: true) }
       before { create_jobs(4, private: false) }
 


### PR DESCRIPTION
Use new concurrency field on Subscription model, to retrieve number of builds instead of retrieving it from Config.

More info: https://github.com/travis-pro/team-teal/issues/2324