### PR TITLE
Send `updated_at` for builds and jobs with Pusher

### DIFF
--- a/lib/travis/scheduler/serialize/live.rb
+++ b/lib/travis/scheduler/serialize/live.rb
@@ -14,7 +14,8 @@ module Travis
             state:              job.state.to_s,
             queue:              job.queue,
             allow_failure:      job.allow_failure,
-            commit:             commit_data
+            commit:             commit_data,
+            updated_at:         format_date_with_ms(job.updated_at)
           }
         end
 
@@ -45,6 +46,10 @@ module Travis
 
           def format_date(date)
             date && date.strftime('%Y-%m-%dT%H:%M:%SZ')
+          end
+
+          def format_date_with_ms(date)
+            date && date.strftime('%Y-%m-%dT%H:%M:%S.%3NZ')
           end
       end
     end

--- a/lib/travis/scheduler/service/notify.rb
+++ b/lib/travis/scheduler/service/notify.rb
@@ -47,6 +47,9 @@ module Travis
           end
 
           def notify_live
+            # we need to always make sure that the data is fresh, because Active
+            # Record doesn't always refresh the updated_at column
+            job.reload
             Live.push(live_payload, live_params)
           end
 

--- a/spec/travis/scheduler/serialize/live_spec.rb
+++ b/spec/travis/scheduler/serialize/live_spec.rb
@@ -19,6 +19,7 @@ describe Travis::Scheduler::Serialize::Live do
       queue:              'builds.gce',
       commit_id:          commit.id,
       allow_failure:      false,
+      updated_at:         job.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%3NZ'),
       commit: {
         id:               commit.id,
         sha:              '62aaef',


### PR DESCRIPTION
We will be treating the updated_at column as a record's version.