### PR TITLE
sort logins for owner groups

### DIFF
--- a/lib/travis/owners/group.rb
+++ b/lib/travis/owners/group.rb
@@ -8,11 +8,11 @@ module Travis
       end
 
       def key
-        logins.join(':')
+        @key ||= logins.join(':')
       end
 
       def logins
-        all.map(&:login)
+        @login ||= all.map(&:login).sort
       end
 
       def max_jobs

--- a/spec/travis/owners_spec.rb
+++ b/spec/travis/owners_spec.rb
@@ -64,9 +64,9 @@ describe Travis::Owners do
     describe 'given an owner group' do
       let(:uuid) { SecureRandom.uuid }
 
-      before { OwnerGroup.create(uuid: uuid, owner_type: 'User', owner_id: anja.id) }
-      before { OwnerGroup.create(uuid: uuid, owner_type: 'User', owner_id: carla.id) }
       before { OwnerGroup.create(uuid: uuid, owner_type: 'Organization', owner_id: travis.id) }
+      before { OwnerGroup.create(uuid: uuid, owner_type: 'User', owner_id: carla.id) }
+      before { OwnerGroup.create(uuid: uuid, owner_type: 'User', owner_id: anja.id) }
 
       it { expect(owners.logins).to eq %w(anja carla travis) }
       it { expect(owners.key).to eq 'anja:carla:travis' }


### PR DESCRIPTION
since we're using the owner group's `key` for locking we need to make sure it's the same no matter the order