### PR TITLE
Compare github ids when checking for non-repo forks

### DIFF
--- a/lib/travis/scheduler/record/request.rb
+++ b/lib/travis/scheduler/record/request.rb
@@ -25,7 +25,7 @@ class Request < ActiveRecord::Base
     # false if Scheduler.config.enterprise is not true.
     return false if read_attribute(:payload).nil?
     # It's not the same repo PR if repo names don't match
-    return false if head_repo != repository.slug
+    return false if head_repo_github_id != repository.github_id
     # It may not be the same repo if head_ref or head_sha are missing
     return false if head_ref.nil? or head_sha.nil?
     # It may not be same repo PR if ref is a commit
@@ -43,8 +43,8 @@ class Request < ActiveRecord::Base
 
   private
 
-    def head_repo
-      pull_request ? pull_request.head_repo_slug : pr.head.try(:repo).try(:full_name)
+    def head_repo_github_id
+      pull_request ? pull_request.head_repo_github_id : pr.head.try(:repo).try(:id)
     end
 
     def head_ref

--- a/spec/travis/scheduler/record/request_spec.rb
+++ b/spec/travis/scheduler/record/request_spec.rb
@@ -1,10 +1,10 @@
 describe Request do
-  let(:repo)         { FactoryGirl.build(:repository, owner_name: 'travis-ci', name: 'travis-ci') }
-  let(:commit)       { FactoryGirl.build(:commit, commit: '12345678') }
-  let(:pull_request) { FactoryGirl.build(:pull_request, head_ref: head_ref, head_repo_slug: head_repo) }
-  let(:request)      { FactoryGirl.build(:request, repository: repo, commit: commit, pull_request: pull_request) }
-  let(:head_repo)    { 'travis-ci/travis-core' }
-  let(:head_ref)     { 'branch-1' }
+  let(:repo)                   { FactoryGirl.build(:repository, owner_name: 'travis-ci', name: 'travis-ci') }
+  let(:commit)                 { FactoryGirl.build(:commit, commit: '12345678') }
+  let(:pull_request)           { FactoryGirl.build(:pull_request, head_ref: head_ref, head_repo_github_id: head_repo_github_id) }
+  let(:request)                { FactoryGirl.build(:request, repository: repo, commit: commit, pull_request: pull_request) }
+  let(:head_repo_github_id)    { repo.github_id }
+  let(:head_ref)               { 'branch-1' }
 
   describe 'same_repo_pull_request?' do
     describe 'returns false if the ref is a sha' do
@@ -13,7 +13,7 @@ describe Request do
     end
 
     describe 'returns false if the base and head repos do not match' do
-      let(:head_repo) { 'evilmonkey-ci/travis-core' }
+      let(:head_repo_github_id) { repo.github_id + 1000 }
       it { expect(request.same_repo_pull_request?).to eq(false) }
     end
 


### PR DESCRIPTION
We shouldn't rely on the repo slug being the same
on head and pr, since repos are easily renamed.

https://github.com/travis-pro/team-teal/issues/2133