### PR TITLE
Revert "Add sudo override when Chrome use detected"

### DIFF
--- a/lib/travis/queue/matcher.rb
+++ b/lib/travis/queue/matcher.rb
@@ -2,7 +2,7 @@ module Travis
   class Queue
     class Matcher < Struct.new(:job, :config, :logger)
       KEYS = %i(slug owner os language sudo dist group osx_image percentage
-        addons services)
+        services)
 
       MSGS = {
         unknown_matchers: 'unknown matchers used for queue %s: %s (repo=%s)"'
@@ -55,10 +55,6 @@ module Travis
           ->(percent) { rand(100) < percent }
         end
 
-        def addons
-          ->(addons) { Array(job.config[:addons] && job.config[:addons].keys.map(&:to_s) & addons).any? }
-        end
-
         def services
           ->(services) { (Array(job.config[:services]) & services).any? }
         end
@@ -69,7 +65,7 @@ module Travis
 
         def check_unknown_matchers(used)
           unknown = used - KEYS
-          logger.warn MSGS[:unknown_matchers] % [used.join(', '), unknown, repo.slug] if logger && unknown.any?
+          logger.warn MSGS[:unknown_matchers] % [name, unknown, repo.slug] if logger && unknown.any?
         end
     end
   end

--- a/lib/travis/queue/sudo.rb
+++ b/lib/travis/queue/sudo.rb
@@ -6,7 +6,6 @@ module Travis
       def value
         return 'required' if force_precise_sudo_required?
         return 'required' if sudo_used?
-        return 'required' if chrome_used?
         return specified if specified?
         default
       end
@@ -31,10 +30,6 @@ module Travis
 
         def sudo_used?
           SudoDetector.new(job_config).detect?
-        end
-
-        def chrome_used?
-          job_config.key?(:addons) && job_config[:addons][:chrome].present?
         end
 
         def repo_created_after_cutoff?

--- a/spec/travis/queue_spec.rb
+++ b/spec/travis/queue_spec.rb
@@ -21,7 +21,6 @@ describe Travis::Queue do
       { queue: 'builds.mac_osx', os: 'osx' },
       { queue: 'builds.docker', sudo: false, dist: 'precise' },
       { queue: 'builds.ec2', sudo: false, dist: 'trusty' },
-      { queue: 'builds.gce', addons: %w(chrome) },
       { queue: 'builds.gce', services: %w(docker) },
       { queue: 'builds.gce', dist: 'trusty', sudo: 'required' },
       { queue: 'builds.gce', dist: 'precise', sudo: 'required' },
@@ -56,11 +55,6 @@ describe Travis::Queue do
     end
     let(:config) { { language: 'php', os: 'linux', group: 'stable', dist: 'precise' } }
     it { expect(queue).to eq 'builds.docker' }
-  end
-
-  describe 'with a chrome addon and sudo: false' do
-    let(:config) { { language: 'node_js', sudo: false, addons: { chrome: 'stable' } } }
-    it { expect(queue).to eq 'builds.gce' }
   end
 
   describe 'by app config' do


### PR DESCRIPTION
Reverts travis-ci/travis-scheduler#118

Due to config type errors in production.

https://sentry.io/travis-ci/org-scheduler-production/issues/431771133/
https://sentry.io/travis-ci/org-scheduler-production/issues/431651882/

Let's figure it out and reintroduce once production has stabilised.