### PR TITLE
honeycomb: change scheduler stats to be less confusing

### DIFF
--- a/lib/travis/scheduler/limit/jobs.rb
+++ b/lib/travis/scheduler/limit/jobs.rb
@@ -99,10 +99,10 @@ module Travis
 
           def honeycomb
             Travis::Honeycomb.context.add('scheduler.stats', {
-              total: queueable.size,
               running: state.running_by_owners,
-              queueable: selected.size,
+              enqueued: selected.size,
               waiting: waiting.size,
+              concurrent: selected.size + state.running_by_owners,
             })
           end
 


### PR DESCRIPTION
* scheduler.stats.queueable => scheduler.stats.enqueued (number of jobs enqueued in this scheduler run)
* remove scheduler.stats.total (it stands for "currently not running" which is not very useful)
* introduce scheduler.stats.concurrent to indicate current concurrency level (scheduler.stats.enqueued + scheduler.stats.running)