### PR TITLE
Don't throw exception when checking if job is enqueable by owner

### DIFF
--- a/lib/travis/scheduler/limit/by_owner.rb
+++ b/lib/travis/scheduler/limit/by_owner.rb
@@ -11,7 +11,7 @@ module Travis
         KEYS = [:by_boost, :by_config, :by_plan, :by_trial, :default]
 
         def enqueue?
-          unlimited || current < max || !public_mode? && throw(:result, :limited)
+          unlimited || current < max
         end
 
         private

--- a/lib/travis/scheduler/limit/by_owner.rb
+++ b/lib/travis/scheduler/limit/by_owner.rb
@@ -74,8 +74,7 @@ module Travis
           end
 
           def running_and_selected_public_jobs_upto_config_limit
-            count = Job.by_owners(owners.all).running.where(private: false).count
-            count = count + selected.select(&:public?).size
+            count = state.running_by_owners_public + selected.select(&:public?).size
             count = [count, config[:limit][:public].to_i].min if config[:limit][:public]
             count
           end

--- a/lib/travis/scheduler/limit/by_stage.rb
+++ b/lib/travis/scheduler/limit/by_stage.rb
@@ -19,19 +19,11 @@ module Travis
           end
 
           def queueable
-            @queueable ||= Stages.build(jobs).startable
+            @queueable ||= Stages.build(state.jobs_by_source(job.source_id)).startable
           end
 
           ATTRS = [:id, :state, :stage_number]
           KEYS  = [:id, :state, :stage]
-
-          def jobs
-            @jobs ||= begin
-              # TODO would it make sense to cache these on `state`?
-              jobs = Job.where(source_id: job.source_id)
-              sort(jobs).map { |job| attrs(job) }
-            end
-          end
 
           def attrs(job)
             {
@@ -47,7 +39,7 @@ module Travis
           end
 
           def stages
-            jobs.map { |job| job[:stage] }
+            state.jobs.map { |job| job[:stage] }
           end
 
           def report

--- a/lib/travis/scheduler/limit/by_stage.rb
+++ b/lib/travis/scheduler/limit/by_stage.rb
@@ -33,11 +33,6 @@ module Travis
             }
           end
 
-          def sort(jobs)
-            num = ->(job) { job.stage_number.split('.').map(&:to_i) }
-            jobs.sort { |lft, rgt| num.(lft) <=> num.(rgt) }
-          end
-
           def stages
             state.jobs.map { |job| job[:stage] }
           end

--- a/lib/travis/scheduler/limit/jobs.rb
+++ b/lib/travis/scheduler/limit/jobs.rb
@@ -62,10 +62,7 @@ module Travis
           # selected for queueing.
           def check_all
             queueable.each do |job|
-              case check(job)
-              when :limited
-                break
-              when true
+              if enqueue?(job)
                 selected << job
               end
             end
@@ -73,10 +70,6 @@ module Travis
 
           def set_queue(job)
             inline :set_queue, job
-          end
-
-          def check(job)
-            catch(:result) { enqueue?(job) }
           end
 
           def enqueue?(job)

--- a/lib/travis/scheduler/limit/jobs.rb
+++ b/lib/travis/scheduler/limit/jobs.rb
@@ -108,7 +108,7 @@ module Travis
           end
 
           def queueable
-            @queueable ||= Job.by_owners(owners.all).queueable.to_a
+            @queueable ||= Job.includes(:repository).by_owners(owners.all).queueable.to_a
           end
           time :queueable, key: 'scheduler.queueable_jobs'
 

--- a/lib/travis/scheduler/limit/state.rb
+++ b/lib/travis/scheduler/limit/state.rb
@@ -11,6 +11,22 @@ module Travis
           @config = config
           @count  = { repo: {}, queue: {} }
           @boosts = {}
+          @jobs = {}
+        end
+
+        def attrs(job)
+          {
+            id:    job.id,
+            stage: job.stage_number,
+            state: job.finished? ? :finished : :created
+          }
+        end
+
+        def jobs_by_source(source_id)
+          @jobs[source_id] ||= begin
+            result = Job.where(source_id: source_id)
+            result.sort.map { |job| attrs(job) }
+          end
         end
 
         def running_by_owners

--- a/lib/travis/scheduler/limit/state.rb
+++ b/lib/travis/scheduler/limit/state.rb
@@ -25,7 +25,7 @@ module Travis
         def jobs_by_source(source_id)
           @jobs[source_id] ||= begin
             result = Job.where(source_id: source_id)
-            result.sort.map { |job| attrs(job) }
+            sort(result).map { |job| attrs(job) }
           end
         end
 
@@ -53,6 +53,11 @@ module Travis
 
           def running_jobs_by_owners
             @running_jobs_by_owners ||= Job.by_owners(owners.all).running
+          end
+
+          def sort(jobs)
+            num = ->(job) { job.stage_number.split('.').map(&:to_i) }
+            jobs.sort { |lft, rgt| num.(lft) <=> num.(rgt) }
           end
       end
     end

--- a/spec/travis/scheduler/limit_spec.rb
+++ b/spec/travis/scheduler/limit_spec.rb
@@ -39,6 +39,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(report).to include('max jobs for user svenfuchs by boost: 2') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 2') }
     it { expect(report).to include('jobs waiting for svenfuchs: svenfuchs/gem-release=1') }
+    it { expect(limit.waiting_by_owner).to eq 1 }
   end
 
   describe 'with a subscription limit 1' do
@@ -49,6 +50,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 1 }
     it { expect(report).to include('max jobs for user svenfuchs by plan: 1 (svenfuchs)') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 1') }
+    it { expect(limit.waiting_by_owner).to eq 2 }
   end
 
   describe 'with a custom config limit unlimited' do
@@ -59,6 +61,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 3 }
     it { expect(report).to include('max jobs for user svenfuchs by unlimited: true') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 3') }
+    it { expect(limit.waiting_by_owner).to eq 0 }
   end
 
   describe 'with a custom config limit 1' do
@@ -69,6 +72,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 1 }
     it { expect(report).to include('max jobs for user svenfuchs by config: 1') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 1') }
+    it { expect(limit.waiting_by_owner).to eq 2 }
   end
 
   describe 'with a trial' do
@@ -80,6 +84,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 2 }
     it { expect(report).to include('max jobs for user svenfuchs by trial: 2') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 2') }
+    it { expect(limit.waiting_by_owner).to eq 1 }
   end
 
   describe 'with a default limit 1' do
@@ -90,6 +95,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 1 }
     it { expect(report).to include('max jobs for user svenfuchs by default: 1') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 1') }
+    it { expect(limit.waiting_by_owner).to eq 2 }
   end
 
   describe 'with a default limit 5 and a repo settings limit 2' do
@@ -101,6 +107,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 2 }
     it { expect(report).to include('max jobs for repo svenfuchs/gem-release by repo_settings: 2') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 2') }
+    it { expect(limit.waiting_by_owner).to eq 0 }
   end
 
   describe 'with a default limit 1 and a repo settings limit 5' do
@@ -115,6 +122,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(report).to include('max jobs for user svenfuchs by plan: 7 (svenfuchs)') }
     it { expect(report).to include('max jobs for repo svenfuchs/gem-release by repo_settings: 5') }
     it { expect(report).to include('user svenfuchs: total: 7, running: 3, queueable: 2') }
+    it { expect(limit.waiting_by_owner).to eq 0 }
   end
 
   describe 'with no by_queue config being given (enterprise)' do
@@ -213,6 +221,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 5 }
     it { expect(report).to include('max jobs for user svenfuchs by default: 5') }
     it { expect(report).to include('user svenfuchs: total: 10, running: 0, queueable: 5') }
+    it { expect(limit.waiting_by_owner).to eq 5 }
   end
 
   describe 'delegated accounts' do
@@ -233,6 +242,7 @@ describe Travis::Scheduler::Limit::Jobs do
       it { expect(subject.map(&:owner).map(&:login)).to eq ['svenfuchs'] * 3 + ['travis-ci'] * 2 }
       it { expect(report).to include('max jobs for user svenfuchs by plan: 7 (travis-ci)') }
       it { expect(report).to include('user svenfuchs, user carla, org travis-ci: total: 6, running: 2, queueable: 5') }
+      it { expect(limit.waiting_by_owner).to eq 1 }
     end
 
     describe 'with multiple subscriptions' do


### PR DESCRIPTION
I'm having a bit of trouble understanding why we need to throw the :limited result for the ByOwner limit check, so I thought I'd use this PR to ask. 😄 

As far as I understand it, we're skipping the job regardless if public_mode is true or false (we just throw the exception in one case and return false in the other). 
I expect it might have some effect on the rest of the jobs (since we `break` when encountering the `:limited` result), but it's not very clear to me why that would be and if that is indeed the case, it would be good to have some unit tests covering it.