### PR TITLE
Optionally display the number of SQL queries performed during test runs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,10 +33,13 @@ RSpec.configure do |c|
   # TODO for webmock request expectation
   c.raise_errors_for_deprecations!
 
-  c.before(:suite) do
-    ActiveSupport::Notifications.subscribe 'sql.active_record' do |*args|
-      event = ActiveSupport::Notifications::Event.new *args
-      sql_count[event.payload[:name]] +=1
+
+  if ENV['SHOW_QUERIES']
+    c.before(:suite) do
+      ActiveSupport::Notifications.subscribe 'sql.active_record' do |*args|
+        event = ActiveSupport::Notifications::Event.new *args
+        sql_count[event.payload[:name]] +=1
+     end
     end
   end
 
@@ -53,10 +56,11 @@ RSpec.configure do |c|
     DatabaseCleaner.clean
   end
 
-  c.after(:suite) do
-    puts
-    puts "Number of SQL queries performed:"
-    puts JSON.pretty_generate(sql_count)
+  if ENV['SHOW_QUERIES']
+    c.after(:suite) do
+      puts "\nNumber of SQL queries performed:"
+      puts JSON.pretty_generate(sql_count)
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@ Travis::Scheduler.setup
 
 DatabaseCleaner.clean_with :truncation
 DatabaseCleaner.strategy = :transaction
-sql_count = Hash.new 0
 
 WebMock.disable_net_connect!
 
@@ -35,6 +34,8 @@ RSpec.configure do |c|
 
 
   if ENV['SHOW_QUERIES']
+    sql_count = {}
+    sql_count.default = 0
     c.before(:suite) do
       ActiveSupport::Notifications.subscribe 'sql.active_record' do |*args|
         event = ActiveSupport::Notifications::Event.new *args


### PR DESCRIPTION
While discussing performance improvements for scheduler @igorwwwwwwwwwwwwwwwwwwww  and I thought this would be a useful addition to our tests.

Output looks like:
```
........................................................................
Number of SQL queries performed:
{
  "": 4243,
  "SCHEMA": 99,
  "SQL": 2998,
  "Request Load": 560,
  "User Load": 597,
  "Organization Load": 104,
  "Job Load": 82,
  "Repository Load": 450,
  "Subscription Load": 180,
  "Stage Load": 5
}
```