### PR TITLE
Count jobs waiting for concurrency

### DIFF
--- a/lib/travis/scheduler/limit/by_owner.rb
+++ b/lib/travis/scheduler/limit/by_owner.rb
@@ -74,8 +74,7 @@ module Travis
           end
 
           def running_and_selected_public_jobs_upto_config_limit
-            count = Job.by_owners(owners.all).running.where(private: false).count
-            count = count + selected.select(&:public?).size
+            count = state.running_by_owners_public + selected.select(&:public?).size
             count = [count, config[:limit][:public].to_i].min if config[:limit][:public]
             count
           end

--- a/spec/travis/scheduler/limit_spec.rb
+++ b/spec/travis/scheduler/limit_spec.rb
@@ -39,6 +39,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(report).to include('max jobs for user svenfuchs by boost: 2') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 2') }
     it { expect(report).to include('jobs waiting for svenfuchs: svenfuchs/gem-release=1') }
+    it { expect(limit.waiting_by_owner).to eq 1 }
   end
 
   describe 'with a subscription limit 1' do
@@ -49,6 +50,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 1 }
     it { expect(report).to include('max jobs for user svenfuchs by plan: 1 (svenfuchs)') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 1') }
+    it { expect(limit.waiting_by_owner).to eq 2 }
   end
 
   describe 'with a custom config limit unlimited' do
@@ -59,6 +61,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 3 }
     it { expect(report).to include('max jobs for user svenfuchs by unlimited: true') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 3') }
+    it { expect(limit.waiting_by_owner).to eq 0 }
   end
 
   describe 'with a custom config limit 1' do
@@ -69,6 +72,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 1 }
     it { expect(report).to include('max jobs for user svenfuchs by config: 1') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 1') }
+    it { expect(limit.waiting_by_owner).to eq 2 }
   end
 
   describe 'with a trial' do
@@ -80,6 +84,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 2 }
     it { expect(report).to include('max jobs for user svenfuchs by trial: 2') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 2') }
+    it { expect(limit.waiting_by_owner).to eq 1 }
   end
 
   describe 'with a default limit 1' do
@@ -90,6 +95,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 1 }
     it { expect(report).to include('max jobs for user svenfuchs by default: 1') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 1') }
+    it { expect(limit.waiting_by_owner).to eq 2 }
   end
 
   describe 'with a default limit 5 and a repo settings limit 2' do
@@ -101,6 +107,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 2 }
     it { expect(report).to include('max jobs for repo svenfuchs/gem-release by repo_settings: 2') }
     it { expect(report).to include('user svenfuchs: total: 3, running: 0, queueable: 2') }
+    it { expect(limit.waiting_by_owner).to eq 0 }
   end
 
   describe 'with a default limit 1 and a repo settings limit 5' do
@@ -115,6 +122,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(report).to include('max jobs for user svenfuchs by plan: 7 (svenfuchs)') }
     it { expect(report).to include('max jobs for repo svenfuchs/gem-release by repo_settings: 5') }
     it { expect(report).to include('user svenfuchs: total: 7, running: 3, queueable: 2') }
+    it { expect(limit.waiting_by_owner).to eq 0 }
   end
 
   describe 'with no by_queue config being given (enterprise)' do
@@ -213,6 +221,7 @@ describe Travis::Scheduler::Limit::Jobs do
     it { expect(subject.size).to eq 5 }
     it { expect(report).to include('max jobs for user svenfuchs by default: 5') }
     it { expect(report).to include('user svenfuchs: total: 10, running: 0, queueable: 5') }
+    it { expect(limit.waiting_by_owner).to eq 5 }
   end
 
   describe 'delegated accounts' do
@@ -233,6 +242,7 @@ describe Travis::Scheduler::Limit::Jobs do
       it { expect(subject.map(&:owner).map(&:login)).to eq ['svenfuchs'] * 3 + ['travis-ci'] * 2 }
       it { expect(report).to include('max jobs for user svenfuchs by plan: 7 (travis-ci)') }
       it { expect(report).to include('user svenfuchs, user carla, org travis-ci: total: 6, running: 2, queueable: 5') }
+      it { expect(limit.waiting_by_owner).to eq 1 }
     end
 
     describe 'with multiple subscriptions' do


### PR DESCRIPTION
This is the compromise we reached as part of https://github.com/travis-ci/reliability/issues/5, since counting by each limit type has a significant performance impact.

For now, we just want to count the jobs that are waiting for concurrency (although **not exclusively for concurrency**) and send this number to honeycomb.

Question:
Should this already pick up jobs waiting after The Merge? (it doesn't currently and I'm not sure if that's expected or not)