### PR TITLE
Track the time jobs spend waiting to be scheduled

### DIFF
--- a/lib/travis/scheduler/service/enqueue_job.rb
+++ b/lib/travis/scheduler/service/enqueue_job.rb
@@ -16,7 +16,7 @@ module Travis
           info MSGS[:queueing] % [job.id, repo.slug]
           Travis::Honeycomb.context.add('job_id', job.id)
           Travis::Honeycomb.context.add('repo_slug', repo.slug)
-          Travis::Honeycomb.context.add('job_waiting_ms', (Time.now - Time.at(job['created_at'])) * 1000)
+          Travis::Honeycomb.context.add('job_waiting_ms', (Time.now - Time.at(job['updated_at'])) * 1000)
           set_queued
           notify
         end

--- a/lib/travis/scheduler/service/enqueue_job.rb
+++ b/lib/travis/scheduler/service/enqueue_job.rb
@@ -16,7 +16,13 @@ module Travis
           info MSGS[:queueing] % [job.id, repo.slug]
           Travis::Honeycomb.context.add('job_id', job.id)
           Travis::Honeycomb.context.add('repo_slug', repo.slug)
-          Travis::Honeycomb.context.add('job_waiting_s', Time.now - Time.at(job['updated_at']))
+          if job['received_at']
+            # job is restarted, so we can't use the 'created_at' time
+            start_time = job['updated_at']
+          else
+            start_time= job['created_at']
+          end
+          Travis::Honeycomb.context.add('job_waiting_s', Time.now - Time.at(start_time))
           set_queued
           notify
         end

--- a/lib/travis/scheduler/service/enqueue_job.rb
+++ b/lib/travis/scheduler/service/enqueue_job.rb
@@ -16,6 +16,7 @@ module Travis
           info MSGS[:queueing] % [job.id, repo.slug]
           Travis::Honeycomb.context.add('job_id', job.id)
           Travis::Honeycomb.context.add('repo_slug', repo.slug)
+          Travis::Honeycomb.context.add('job_waiting_ms', (Time.now - Time.at(job['created_at'])) * 1000)
           set_queued
           notify
         end

--- a/lib/travis/scheduler/service/enqueue_job.rb
+++ b/lib/travis/scheduler/service/enqueue_job.rb
@@ -16,7 +16,7 @@ module Travis
           info MSGS[:queueing] % [job.id, repo.slug]
           Travis::Honeycomb.context.add('job_id', job.id)
           Travis::Honeycomb.context.add('repo_slug', repo.slug)
-          Travis::Honeycomb.context.add('job_waiting_ms', (Time.now - Time.at(job['updated_at'])) * 1000)
+          Travis::Honeycomb.context.add('job_waiting_s', Time.now - Time.at(job['updated_at']))
           set_queued
           notify
         end

--- a/lib/travis/scheduler/service/notify.rb
+++ b/lib/travis/scheduler/service/notify.rb
@@ -33,7 +33,6 @@ module Travis
             info "Publishing worker payload for job=#{job.id} queue=#{job.queue}"
             Travis::Honeycomb.context.add('job_id', job.id)
             Travis::Honeycomb.context.add('queue', job.queue)
-            Travis::Honeycomb.context.add('job_waiting_ms', (Time.now - Time.at(job['created_at'])) * 1000)
             rollout? ? notify_job_board : notify_rabbitmq
           end
 

--- a/lib/travis/scheduler/service/notify.rb
+++ b/lib/travis/scheduler/service/notify.rb
@@ -33,6 +33,7 @@ module Travis
             info "Publishing worker payload for job=#{job.id} queue=#{job.queue}"
             Travis::Honeycomb.context.add('job_id', job.id)
             Travis::Honeycomb.context.add('queue', job.queue)
+            Travis::Honeycomb.context.add('job_waiting_ms', (Time.now - Time.at(job['created_at'])) * 1000)
             rollout? ? notify_job_board : notify_rabbitmq
           end
 


### PR DESCRIPTION
In order to give more information to Team Jade that they could use to upsell clients, we should also keep track of how long jobs are waiting (based on the different limits that are imposed) to be scheduled and send that to Honeycomb. 

I initially calculated that as `Time.now` (which is the time when the job is actually sent to one of the infra queues to be run by the worker) - `Time.at(job['created_at'])`, but that meant getting huge durations for jobs that were restarted (which had `created_at` dates long in the past). Therefore, I think using `updated_at` should work well enough in this case.