### PR TITLE
delete DATABASE_URL from ENV in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 ENV['ENV'] = ENV['RAILS_ENV'] = 'test'
+ENV.delete('DATABASE_URL')
 
 require 'database_cleaner'
 require 'mocha'


### PR DESCRIPTION
extra safety net for not accidentally running specs against a remote database