### PR TITLE
Add additional context for configurable timeouts

### DIFF
--- a/lib/travis/scheduler/record/organization.rb
+++ b/lib/travis/scheduler/record/organization.rb
@@ -1,5 +1,15 @@
 class Organization < ActiveRecord::Base
 
+  # These default timeouts, for Users and Organzations, are for limiting workers
+  #   from living forever, and should not be adjusted without checking with
+  #   builders on the infrastructure or reliability teams. Changing them will
+  #   impact our resource usage as well as our ability to rollout new workers.
+  #
+  # Note: timeout values are in seconds
+  #
+  DEFAULT_SUBSCRIBED_TIMEOUT = 120 * 60
+  DEFAULT_SPONSORED_TIMEOUT  = 50 * 60
+
   def subscription
     subs = Subscription.where(owner_id: id, owner_type: "Organization")
     @subscription ||= subs.where(status: 'subscribed').last || subs.last
@@ -14,16 +24,17 @@ class Organization < ActiveRecord::Base
   end
 
   def default_worker_timeout
-    # When the organization is a paid account ("subscribed") or has an active
-    #   trial, they are granted a different default timeout on their jobs.
+    # When the user is a paid user ("subscribed") or has an active trial, they
+    #   are granted a different default timeout on their jobs.
     #
-    # Note that currently (27/4/18) we are NOT providing different timeouts, but
-    #   we plan to sometime in the following weeks/months.
+    # Note that currently (27/4/18) we are NOT providing timeouts different from
+    #   those enforced by workers themselves, but we plan to sometime in the
+    #   following weeks/months.
     #
     if subscribed? || active_trial?
-      120 * 60 # timeouts are in seconds
+      DEFAULT_SUBSCRIBED_TIMEOUT
     else
-      60 * 60
+      DEFAULT_SPONSORED_TIMEOUT
     end
   end
 

--- a/lib/travis/scheduler/record/user.rb
+++ b/lib/travis/scheduler/record/user.rb
@@ -4,6 +4,16 @@ require 'travis/support/encrypted_column'
 class User < ActiveRecord::Base
   serialize :github_oauth_token, Travis::EncryptedColumn.new
 
+  # These default timeouts, for Users and Organzations, are for limiting workers
+  #   from living forever, and should not be adjusted without checking with
+  #   builders on the infrastructure or reliability teams. Changing them will
+  #   impact our resource usage as well as our ability to rollout new workers.
+  #
+  # Note: timeout values are in seconds
+  #
+  DEFAULT_SUBSCRIBED_TIMEOUT = 120 * 60
+  DEFAULT_SPONSORED_TIMEOUT  = 50 * 60
+
   def subscription
     subs = Subscription.where(owner_id: id, owner_type: "User")
     @subscription ||= subs.where(status: 'subscribed').last || subs.last
@@ -21,13 +31,14 @@ class User < ActiveRecord::Base
     # When the user is a paid user ("subscribed") or has an active trial, they
     #   are granted a different default timeout on their jobs.
     #
-    # Note that currently (27/4/18) we are NOT providing different timeouts, but
-    #   we plan to sometime in the following weeks/months.
+    # Note that currently (27/4/18) we are NOT providing timeouts different from
+    #   those enforced by workers themselves, but we plan to sometime in the
+    #   following weeks/months.
     #
     if subscribed? || active_trial?
-      120 * 60 # timeouts are in seconds
+      DEFAULT_SUBSCRIBED_TIMEOUT
     else
-      60 * 60
+      DEFAULT_SPONSORED_TIMEOUT
     end
   end
 

--- a/spec/travis/scheduler/record/organization_spec.rb
+++ b/spec/travis/scheduler/record/organization_spec.rb
@@ -1,0 +1,47 @@
+describe Organization do
+  let(:org) { FactoryGirl.create(:org) }
+
+  describe "constants" do
+    # It isn't often that we see tests for constants, but these are special.
+    #   Changing these values for worker timeout limits impacts our infra teams,
+    #   and should only be adjusted after consulting with them.
+    #
+    it "has correct values for default timeouts" do
+      expect(Organization::DEFAULT_SPONSORED_TIMEOUT).to eq 3000
+      expect(Organization::DEFAULT_SUBSCRIBED_TIMEOUT).to eq 7200
+    end
+  end
+
+  describe "#default_worker_timeout" do
+    context "subscribed? == true" do
+      before do
+        org.stubs(:subscribed?).returns(true)
+      end
+
+      it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do
+        expect(org.default_worker_timeout).to eq Organization::DEFAULT_SUBSCRIBED_TIMEOUT
+      end
+    end
+
+    context "active_trial? == true" do
+      before do
+        org.stubs(:active_trial?).returns(true)
+      end
+
+      it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do
+        expect(org.default_worker_timeout).to eq Organization::DEFAULT_SUBSCRIBED_TIMEOUT
+      end
+    end
+
+    context "subscribed? == false && active_trial? == false" do
+      before do
+        org.stubs(:subscribed?).returns(false)
+        org.stubs(:active_trial?).returns(false)
+      end
+
+      it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do
+        expect(org.default_worker_timeout).to eq Organization::DEFAULT_SPONSORED_TIMEOUT
+      end
+    end
+  end
+end

--- a/spec/travis/scheduler/record/user_spec.rb
+++ b/spec/travis/scheduler/record/user_spec.rb
@@ -1,0 +1,47 @@
+describe User do
+  let(:user) { FactoryGirl.create(:user) }
+
+  describe "constants" do
+    # It isn't often that we see tests for constants, but these are special.
+    #   Changing these values for worker timeout limits impacts our infra teams,
+    #   and should only be adjusted after consulting with them.
+    #
+    it "has correct values for default timeouts" do
+      expect(User::DEFAULT_SPONSORED_TIMEOUT).to eq 3000
+      expect(User::DEFAULT_SUBSCRIBED_TIMEOUT).to eq 7200
+    end
+  end
+
+  describe "#default_worker_timeout" do
+    context "subscribed? == true" do
+      before do
+        user.stubs(:subscribed?).returns(true)
+      end
+
+      it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do
+        expect(user.default_worker_timeout).to eq User::DEFAULT_SUBSCRIBED_TIMEOUT
+      end
+    end
+
+    context "active_trial? == true" do
+      before do
+        user.stubs(:active_trial?).returns(true)
+      end
+
+      it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do
+        expect(user.default_worker_timeout).to eq User::DEFAULT_SUBSCRIBED_TIMEOUT
+      end
+    end
+
+    context "subscribed? == false && active_trial? == false" do
+      before do
+        user.stubs(:subscribed?).returns(false)
+        user.stubs(:active_trial?).returns(false)
+      end
+
+      it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do
+        expect(user.default_worker_timeout).to eq User::DEFAULT_SPONSORED_TIMEOUT
+      end
+    end
+  end
+end

--- a/spec/travis/scheduler/serialize/worker/repo_spec.rb
+++ b/spec/travis/scheduler/serialize/worker/repo_spec.rb
@@ -8,8 +8,8 @@ describe Travis::Scheduler::Serialize::Worker::Repo do
 
   let(:config) { { github: {} } }
 
-  let(:unpaid_timeout) { 3600 }
-  let(:paid_timeout)   { 7200 }
+  let(:unpaid_timeout) { User::DEFAULT_SPONSORED_TIMEOUT }
+  let(:paid_timeout)   { User::DEFAULT_SUBSCRIBED_TIMEOUT }
 
   subject { described_class.new(repo, config) }
 


### PR DESCRIPTION
Wanted to provide more context for the timeout knob, especially around the topic of adjusting it upwards, which @igorwwwwwwwwwwwwwwwwwwww pointed out to me can cause (and has caused) issues.