### PR TITLE
Drop JWT addon support

### DIFF
--- a/lib/travis/scheduler/serialize/worker/config.rb
+++ b/lib/travis/scheduler/serialize/worker/config.rb
@@ -15,7 +15,6 @@ module Travis
               config = deep_dup(config)
               config = Normalize.new(config, options).apply
               config = Decrypt.new(config, decryptor, options).apply
-              config = Normalize.new(config, options).jwt_sanitize
               config
             end
           end

--- a/lib/travis/scheduler/serialize/worker/config/addons.rb
+++ b/lib/travis/scheduler/serialize/worker/config/addons.rb
@@ -13,7 +13,6 @@ module Travis
               firefox
               hostname
               hosts
-              jwt
               mariadb
               postgresql
               rethinkdb
@@ -21,46 +20,9 @@ module Travis
               ssh_known_hosts
             )
 
-            JWT_AWARE = %i(
-              sauce_connect
-            )
-
-            JWT_ENV_CHECKS = {
-              sauce_connect: {
-                'SAUCE_ACCESS_KEY' => {
-                  minimum_length: 20
-                }
-              }
-            }
-
             def apply
               config = compact(filtered)
               config unless config.empty?
-            end
-
-            def jwt_sanitize
-              # this method would be called once we have filtered the safelisted and jwt_aware addons,
-              # and the values have been decrypted we would have something like passed on to this method:
-              #
-              # {:sauce_connect=>{:username=>"sauce_connect_user"}, :jwt=>"SAUCE_ACCESS_KEY=foo1123456789012345657889"}
-              #
-              # and we want to drop the values of the :jwt addon that does not meet the criteria
-              # set forth by JWT_ENV_CHECKS
-
-              jwt_config = Array(config.delete(:jwt))
-
-              return config if jwt_config.empty?
-
-              config[:jwt] = jwt_config.select do |decrypted_jwt_data|
-                return unless decrypted_jwt_data.respond_to?(:split)
-                env_var_name, env_var_value = decrypted_jwt_data.split('=', 2)
-
-                JWT_ENV_CHECKS.any? do |addon, criteria|
-                  criteria.key?(env_var_name) && criteria[env_var_name][:minimum_length] <= env_var_value.length
-                end
-              end
-
-              config
             end
 
             private
@@ -71,8 +33,6 @@ module Travis
             def filter(name, config)
               if safe?(name)
                 config
-              elsif jwt? && jwt_aware?(name)
-                strip_encrypted(config)
               else
                 nil
               end
@@ -91,14 +51,6 @@ module Travis
 
             def safe?(name)
               SAFE.include?(name.to_sym)
-            end
-
-            def jwt?
-              config.keys.include?(:jwt)
-            end
-
-            def jwt_aware?(name)
-              JWT_AWARE.include?(name.to_sym)
             end
 
             def encrypted?(value)

--- a/lib/travis/scheduler/serialize/worker/config/normalize.rb
+++ b/lib/travis/scheduler/serialize/worker/config/normalize.rb
@@ -13,7 +13,6 @@ module Travis
               firefox
               hostname
               hosts
-              jwt
               mariadb
               postgresql
               rethinkdb
@@ -33,13 +32,6 @@ module Travis
               normalize_addons
               filter_addons    if config[:addons] && !full_addons?
               compact(config)
-            end
-
-            def jwt_sanitize
-              if config && config.fetch(:addons,{}).key?(:jwt)
-                config[:addons] = Addons.new(config[:addons]).jwt_sanitize
-              end
-              config
             end
 
             private

--- a/spec/travis/scheduler/serialize/worker/config_spec.rb
+++ b/spec/travis/scheduler/serialize/worker/config_spec.rb
@@ -116,17 +116,11 @@ describe Travis::Scheduler::Serialize::Worker::Config do
       end
     end
 
-    described_class::Addons::SAFE.map(&:to_sym).delete_if {|name| name == :jwt}.each do |name|
+    described_class::Addons::SAFE.map(&:to_sym).each do |name|
       describe "keeps the #{name} addon" do
         let(:config) { { addons: { name => :config } } }
         it { should eql(config) }
       end
-    end
-
-    describe 'jwt encrypted env var' do
-      let(:var)    { 'SAUCE_ACCESS_KEY=foo012345678901234565789' }
-      let(:config) { { addons: { jwt: encrypt(var) } } }
-      it { should eql(addons: { jwt: Array(var) }) }
     end
   end
 
@@ -141,65 +135,6 @@ describe Travis::Scheduler::Serialize::Worker::Config do
     describe 'decrypts deploy addon config' do
       let(:config) { { deploy: { foo: encrypt('foobar') } } }
       it { should eql(addons: { deploy: { foo: 'foobar' } }) }
-    end
-  end
-
-  describe 'jwt addon with encrypted data' do
-    let(:var)    { "SAUCE_ACCESS_KEY=#{sauce_access_key}" }
-    let(:config) { { addons: { sauce_connect: { username: 'sauce_connect_user' }, jwt: encrypt(var) } } }
-
-    shared_examples_for 'includes the decrypted jwt addon config' do
-      describe 'jwt encrypted env var' do
-        it { expect(subject[:addons][:jwt]).to eq Array(var) }
-      end
-    end
-
-    shared_examples_for 'does not include the decrypted jwt addon config' do
-      describe 'jwt encrypted env var' do
-        it { expect(subject[:addons][:jwt]).to eq [] }
-      end
-    end
-
-    context "with long SAUCE_ACCESS_KEY" do
-      let(:sauce_access_key) { 'foo012345678901234565789' }
-
-      describe 'on a push request' do
-        let(:options) { { full_addons: true } }
-        include_examples 'includes the decrypted jwt addon config'
-      end
-
-      describe 'on a pull request' do
-        let(:options) { { full_addons: false } }
-        include_examples 'includes the decrypted jwt addon config'
-      end
-    end
-
-    context "with short SAUCE_ACCESS_KEY" do
-      let(:sauce_access_key) { 'foo' }
-
-      describe 'on a push request' do
-        let(:options) { { full_addons: true } }
-        include_examples 'does not include the decrypted jwt addon config'
-      end
-
-      describe 'on a pull request' do
-        let(:options) { { full_addons: false } }
-        include_examples 'does not include the decrypted jwt addon config'
-      end
-    end
-
-    context "with non-safelisted env var" do
-      let(:var) { "ARBITRARY_ACCESS_KEY=foo012345678901234565789" }
-
-      describe 'on a push request' do
-        let(:options) { { full_addons: true } }
-        include_examples 'does not include the decrypted jwt addon config'
-      end
-
-      describe 'on a pull request' do
-        let(:options) { { full_addons: false } }
-        include_examples 'does not include the decrypted jwt addon config'
-      end
     end
   end
 


### PR DESCRIPTION
As [previously announced](https://blog.travis-ci.com/2018-01-23-jwt-addon-is-deprecated), we will remove JWT addon support. This is a part of the deprecation effort.