### PR TITLE
Add host to worker payload

### DIFF
--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -9,6 +9,7 @@ module Travis
              encryption: { key: SecureRandom.hex(64) },
              enterprise: false,
              github:     { api_url: 'https://api.github.com', source_host: 'github.com' },
+             host:       'https://travis-ci.com',
              interval:   2,
              limit:      { public: 5, default: 5, by_owner: {}, delegate: {} },
              lock:       { strategy: :redis, ttl: 150 },

--- a/lib/travis/scheduler/serialize/worker.rb
+++ b/lib/travis/scheduler/serialize/worker.rb
@@ -18,6 +18,7 @@ module Travis
             config: job.decrypted_config,
             env_vars: job.env_vars,
             job: job_data,
+            host: Travis::Scheduler.config.host,
             source: build_data,
             repository: repository_data,
             ssh_key: ssh_key.data,

--- a/spec/travis/scheduler/serialize/worker_spec.rb
+++ b/spec/travis/scheduler/serialize/worker_spec.rb
@@ -66,6 +66,7 @@ describe Travis::Scheduler::Serialize::Worker do
           allow_failure: allow_failure,
           stage_name: nil,
         },
+        host: 'https://travis-ci.com',
         source: {
           id: build.id,
           number: '2',
@@ -213,6 +214,7 @@ describe Travis::Scheduler::Serialize::Worker do
           allow_failure: allow_failure,
           stage_name: nil,
         },
+        host: 'https://travis-ci.com',
         source: {
           id: build.id,
           number: '2',


### PR DESCRIPTION
Put the host name of the Travis installation so that `travis-build`
may consume it.

This is useful for constructing environment variables that points
to the build/job log from the build/job itself.