### PR TITLE
pgbouncer buildpack for more effective connection pooling

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 console:   bundle exec je ./bin/console
-sidekiq:   bundle exec je bin/sidekiq ${SIDEKIQ_CONCURRENCY:-5} ${SIDEKIQ_QUEUE:-scheduler}
-scheduler: bundle exec je bin/sidekiq ${SIDEKIQ_CONCURRENCY:-5} ${SIDEKIQ_QUEUE:-scheduler}
+sidekiq:   bundle exec je bin/sidekiq-pgbouncer ${SIDEKIQ_CONCURRENCY:-5} ${SIDEKIQ_QUEUE:-scheduler}
+scheduler: bundle exec je bin/sidekiq-pgbouncer ${SIDEKIQ_CONCURRENCY:-5} ${SIDEKIQ_QUEUE:-scheduler}

--- a/bin/sidekiq-pgbouncer
+++ b/bin/sidekiq-pgbouncer
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# this script enables a pgbouncer wrapper when the
+# $PGBOUNCER_ENABLED variable is set to 'true'
+# or if the space-delimited list
+# $PGBOUNCER_ENABLED_FOR_DYNOS contains $DYNO
+
+cd "$(dirname "$0")/.."
+
+for d in $PGBOUNCER_ENABLED_FOR_DYNOS; do
+  if [ "$d" = "$DYNO" ]; then
+    export PGBOUNCER_ENABLED=true
+  fi
+done
+
+if [ ! -f "bin/start-pgbouncer-stunnel" ]; then
+  echo "warning: pgbouncer buildpack not found, setting PGBOUNCER_ENABLED=false"
+  export PGBOUNCER_ENABLED=false
+fi
+
+if [ "$PGBOUNCER_ENABLED" = 'true' ]; then
+  export PGBOUNCER_PREPARED_STATEMENTS=false
+  exec bin/start-pgbouncer-stunnel bin/sidekiq "$@"
+else
+  exec bin/sidekiq "$@"
+fi


### PR DESCRIPTION
to add the buildpack to an application:

```
$ heroku buildpacks:add https://github.com/travis-ci/heroku-buildpack-pgbouncer -a travis-scheduler-staging
$ heroku config:set PGBOUNCER_DEFAULT_POOL_SIZE=5 PGBOUNCER_CONNECT_QUERY='set statement_timeout to 10000' -a travis-scheduler-staging
$ heroku config:set PGBOUNCER_ENABLED=true -a travis-scheduler-staging
```

and on prod (to match `SIDEKIQ_CONCURRENCY`):

```
$ heroku config:set DB_POOL=30 SIDEKIQ_CONCURRENCY=30 -a travis-scheduler-production
$ heroku config:set DB_POOL=25 -a travis-pro-scheduler-prod
```

refs travis-ci/reliability#97 https://github.com/travis-ci/travis-gatekeeper/pull/346