### PR TITLE
Recognize educational users as subscribed for timeout purposes

### DIFF
--- a/lib/travis/scheduler/record/organization.rb
+++ b/lib/travis/scheduler/record/organization.rb
@@ -19,6 +19,10 @@ class Organization < ActiveRecord::Base
     subscription.present? && subscription.active?
   end
 
+  def educational?
+    !!Travis::Features.owner_active?(:educational_org, self)
+  end
+
   def active_trial?
     redis.get("trial:#{login}").to_i > 0
   end

--- a/lib/travis/scheduler/record/organization.rb
+++ b/lib/travis/scheduler/record/organization.rb
@@ -35,7 +35,7 @@ class Organization < ActiveRecord::Base
     #   those enforced by workers themselves, but we plan to sometime in the
     #   following weeks/months.
     #
-    if subscribed? || active_trial?
+    if subscribed? || active_trial? || educational?
       DEFAULT_SUBSCRIBED_TIMEOUT
     else
       DEFAULT_SPONSORED_TIMEOUT

--- a/lib/travis/scheduler/record/user.rb
+++ b/lib/travis/scheduler/record/user.rb
@@ -27,6 +27,10 @@ class User < ActiveRecord::Base
     redis.get("trial:#{login}").to_i > 0
   end
 
+  def educational?
+    !!education
+  end
+
   def default_worker_timeout
     # When the user is a paid user ("subscribed") or has an active trial, they
     #   are granted a different default timeout on their jobs.

--- a/lib/travis/scheduler/record/user.rb
+++ b/lib/travis/scheduler/record/user.rb
@@ -39,7 +39,7 @@ class User < ActiveRecord::Base
     #   those enforced by workers themselves, but we plan to sometime in the
     #   following weeks/months.
     #
-    if subscribed? || active_trial?
+    if subscribed? || active_trial? || educational?
       DEFAULT_SUBSCRIBED_TIMEOUT
     else
       DEFAULT_SPONSORED_TIMEOUT

--- a/spec/travis/scheduler/record/organization_spec.rb
+++ b/spec/travis/scheduler/record/organization_spec.rb
@@ -12,6 +12,38 @@ describe Organization do
     end
   end
 
+  describe "#educational?" do
+    context "education = true" do
+      before do
+        Travis::Features.stubs(:owner_active?).returns(true)
+      end
+
+      it "returns true" do
+        expect(org.educational?).to be_truthy
+      end
+    end
+
+    context "education = false" do
+      before do
+        Travis::Features.stubs(:owner_active?).returns(false)
+      end
+
+      it "returns true" do
+        expect(org.educational?).to be_falsey
+      end
+    end
+
+    context "education = nil" do
+      before do
+        Travis::Features.stubs(:owner_active?).returns(nil)
+      end
+
+      it "returns true" do
+        expect(org.educational?).to be_falsey
+      end
+    end
+  end
+
   describe "#default_worker_timeout" do
     context "subscribed? == true" do
       before do

--- a/spec/travis/scheduler/record/organization_spec.rb
+++ b/spec/travis/scheduler/record/organization_spec.rb
@@ -65,10 +65,21 @@ describe Organization do
       end
     end
 
-    context "subscribed? == false && active_trial? == false" do
+    context "subscribed? == true" do
+      before do
+        org.stubs(:educational?).returns(true)
+      end
+
+      it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do
+        expect(org.default_worker_timeout).to eq Organization::DEFAULT_SUBSCRIBED_TIMEOUT
+      end
+    end
+
+    context "#subscribed?, #active_trial?, #educational? == false" do
       before do
         org.stubs(:subscribed?).returns(false)
         org.stubs(:active_trial?).returns(false)
+        org.stubs(:educational?).returns(false)
       end
 
       it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do

--- a/spec/travis/scheduler/record/user_spec.rb
+++ b/spec/travis/scheduler/record/user_spec.rb
@@ -12,6 +12,38 @@ describe User do
     end
   end
 
+  describe "#educational?" do
+    context "education = true" do
+      before do
+        user.education = true
+      end
+
+      it "returns true" do
+        expect(user.educational?).to be_truthy
+      end
+    end
+
+    context "education = false" do
+      before do
+        user.education = false
+      end
+
+      it "returns true" do
+        expect(user.educational?).to be_falsey
+      end
+    end
+
+    context "education = nil" do
+      before do
+        user.education = nil
+      end
+
+      it "returns true" do
+        expect(user.educational?).to be_falsey
+      end
+    end
+  end
+
   describe "#default_worker_timeout" do
     context "subscribed? == true" do
       before do

--- a/spec/travis/scheduler/record/user_spec.rb
+++ b/spec/travis/scheduler/record/user_spec.rb
@@ -75,7 +75,7 @@ describe User do
       end
     end
 
-    context "#subscribed?, #active_trial?, #educational == false" do
+    context "#subscribed?, #active_trial?, #educational? == false" do
       before do
         user.stubs(:subscribed?).returns(false)
         user.stubs(:active_trial?).returns(false)

--- a/spec/travis/scheduler/record/user_spec.rb
+++ b/spec/travis/scheduler/record/user_spec.rb
@@ -55,6 +55,16 @@ describe User do
       end
     end
 
+    context "educational? == true" do
+      before do
+        user.stubs(:educational?).returns(true)
+      end
+
+      it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do
+        expect(user.default_worker_timeout).to eq User::DEFAULT_SUBSCRIBED_TIMEOUT
+      end
+    end
+
     context "active_trial? == true" do
       before do
         user.stubs(:active_trial?).returns(true)
@@ -65,10 +75,11 @@ describe User do
       end
     end
 
-    context "subscribed? == false && active_trial? == false" do
+    context "#subscribed?, #active_trial?, #educational == false" do
       before do
         user.stubs(:subscribed?).returns(false)
         user.stubs(:active_trial?).returns(false)
+        user.stubs(:educational?).returns(false)
       end
 
       it "returns the DEFAULT_SUBSCRIBED_TIMEOUT" do


### PR DESCRIPTION
If a User or Org is an "Educational" account, use the "subscribed timeout" value.