### PR TITLE
Protect against missing column config on requests, builds, jobs

### DIFF
--- a/lib/travis/scheduler/record/job.rb
+++ b/lib/travis/scheduler/record/job.rb
@@ -77,7 +77,7 @@ class Job < ActiveRecord::Base
   end
 
   def config
-    config = super&.config || read_attribute(:config) || {}
+    config = super&.config || has_attribute?(:config) && read_attribute(:config) || {}
     config.deep_symbolize_keys!
   end
 end


### PR DESCRIPTION
`read_attribute` returns `nil` anyway if the column is missing, but it looks like they are currently still debating if that is a bug or not https://github.com/rails/rails/issues/31017