### PR TITLE
Include vm config in job serialization if present

### DIFF
--- a/lib/travis/scheduler/serialize/worker.rb
+++ b/lib/travis/scheduler/serialize/worker.rb
@@ -13,6 +13,7 @@ module Travis
         def data
           data = {
             type: :test,
+            vm_config: repo.vm_config,
             vm_type: repo.vm_type,
             queue: job.queue,
             config: job.decrypted_config,

--- a/lib/travis/scheduler/serialize/worker/repo.rb
+++ b/lib/travis/scheduler/serialize/worker/repo.rb
@@ -17,6 +17,10 @@ module Travis
             Features.active?(:premium_vms, repo) ? :premium : :default
           end
 
+          def vm_config
+            repo_vm_configs.find { |c| c[:repo] == slug } || {}
+          end
+
           def timeouts
             { hard_limit: hard_limit_timeout, log_silence: timeout(:log_silence) }
           end
@@ -64,6 +68,10 @@ module Travis
 
             def source_host
               config[:github][:source_host] || 'github.com'
+            end
+
+            def repo_vm_configs
+              config[:repo_vm_configs] || {}
             end
         end
       end

--- a/lib/travis/scheduler/serialize/worker/repo.rb
+++ b/lib/travis/scheduler/serialize/worker/repo.rb
@@ -18,7 +18,7 @@ module Travis
           end
 
           def vm_config
-            repo_vm_configs.find { |c| c[:repo] == slug } || {}
+            vm_configs[slug] || {}
           end
 
           def timeouts
@@ -70,8 +70,8 @@ module Travis
               config[:github][:source_host] || 'github.com'
             end
 
-            def repo_vm_configs
-              config[:repo_vm_configs] || {}
+            def vm_configs
+              config[:vm_configs] || {}
             end
         end
       end

--- a/spec/travis/scheduler/serialize/worker_spec.rb
+++ b/spec/travis/scheduler/serialize/worker_spec.rb
@@ -13,7 +13,7 @@ describe Travis::Scheduler::Serialize::Worker do
   let(:repo)      { FactoryGirl.create(:repo, default_branch: 'branch') }
   let(:owner)     { repo.owner }
   let(:data)      { described_class.new(job, config).data }
-  let(:config)    { { cache_settings: { 'builds.gce' => s3 }, github: { source_host: 'github.com', api_url: 'https://api.github.com' }, repo_vm_configs: [] } }
+  let(:config)    { { cache_settings: { 'builds.gce' => s3 }, github: { source_host: 'github.com', api_url: 'https://api.github.com' }, vm_configs: {} } }
   let(:s3)        { { access_key_id: 'ACCESS_KEY_ID', secret_access_key: 'SECRET_ACCESS_KEY', bucket_name: 'bucket' } }
   let(:event)     { 'push' }
   let(:ref)       { 'refs/tags/v1.2.3' }
@@ -167,8 +167,8 @@ describe Travis::Scheduler::Serialize::Worker do
   end
 
   describe 'vm_config' do
-    before { config[:repo_vm_configs] = [{repo: 'svenfuchs/gem-release', bloop: :floop}] }
-    it { expect(data[:vm_config]).to eq(repo: 'svenfuchs/gem-release', bloop: :floop) }
+    before { config[:vm_configs] = { 'svenfuchs/gem-release' => { bloop: :floop } } }
+    it { expect(data[:vm_config]).to eq(bloop: :floop) }
   end
 
   describe 'with debug options' do

--- a/spec/travis/scheduler/serialize/worker_spec.rb
+++ b/spec/travis/scheduler/serialize/worker_spec.rb
@@ -39,6 +39,7 @@ describe Travis::Scheduler::Serialize::Worker do
       expect(data).to eq(
         type: :test,
         vm_type: :default,
+        vm_config: {},
         queue: 'builds.gce',
         config: {
           rvm: '1.8.7',
@@ -189,6 +190,7 @@ describe Travis::Scheduler::Serialize::Worker do
       expect(data).to eq(
         type: :test,
         vm_type: :default,
+        vm_config: {},
         queue: 'builds.gce',
         config: {
           rvm: '1.8.7',

--- a/spec/travis/scheduler/serialize/worker_spec.rb
+++ b/spec/travis/scheduler/serialize/worker_spec.rb
@@ -13,7 +13,7 @@ describe Travis::Scheduler::Serialize::Worker do
   let(:repo)      { FactoryGirl.create(:repo, default_branch: 'branch') }
   let(:owner)     { repo.owner }
   let(:data)      { described_class.new(job, config).data }
-  let(:config)    { { cache_settings: { 'builds.gce' => s3 }, github: { source_host: 'github.com', api_url: 'https://api.github.com' } } }
+  let(:config)    { { cache_settings: { 'builds.gce' => s3 }, github: { source_host: 'github.com', api_url: 'https://api.github.com' }, repo_vm_configs: [] } }
   let(:s3)        { { access_key_id: 'ACCESS_KEY_ID', secret_access_key: 'SECRET_ACCESS_KEY', bucket_name: 'bucket' } }
   let(:event)     { 'push' }
   let(:ref)       { 'refs/tags/v1.2.3' }
@@ -163,6 +163,11 @@ describe Travis::Scheduler::Serialize::Worker do
       after  { features.deactivate_owner(:premium_vms, owner) }
       it { expect(data[:vm_type]).to eq(:premium) }
     end
+  end
+
+  describe 'vm_config' do
+    before { config[:repo_vm_configs] = [{repo: 'svenfuchs/gem-release', bloop: :floop}] }
+    it { expect(data[:vm_config]).to eq(repo: 'svenfuchs/gem-release', bloop: :floop) }
   end
 
   describe 'with debug options' do


### PR DESCRIPTION
This is intended to complement https://github.com/travis-ci/worker/pull/466

The implementation here reads config hashes from yaml config, which may be good enough for the beta period, but we may also want to eventually move to storing the config hashes in database or similar.