### PR TITLE
Resources/vm_configs

### DIFF
--- a/lib/travis/queue.rb
+++ b/lib/travis/queue.rb
@@ -28,8 +28,8 @@ module Travis
   end
 end
 
-require 'travis/queue/sudo'
 require 'travis/queue/matcher'
 require 'travis/queue/pool'
 require 'travis/queue/queues'
+require 'travis/queue/sudo'
 require 'travis/queue/sudo_detector'

--- a/lib/travis/queue/queues.rb
+++ b/lib/travis/queue/queues.rb
@@ -10,7 +10,7 @@ module Travis
       private
 
         def queues
-          @queues ||= Array(config).compact.map do |attrs|
+          Array(config).compact.map do |attrs|
             Queue.new(attrs[:queue], attrs.reject { |key, _| key == :queue })
           end
         end

--- a/lib/travis/scheduler/serialize/worker.rb
+++ b/lib/travis/scheduler/serialize/worker.rb
@@ -13,7 +13,7 @@ module Travis
         def data
           data = {
             type: :test,
-            vm_config: repo.vm_config,
+            vm_config: job.vm_config,
             vm_type: repo.vm_type,
             queue: job.queue,
             config: job.decrypted_config,
@@ -99,7 +99,7 @@ module Travis
           end
 
           def job
-            @job ||= Job.new(super)
+            @job ||= Job.new(super, config)
           end
 
           def repo

--- a/lib/travis/scheduler/serialize/worker/job.rb
+++ b/lib/travis/scheduler/serialize/worker/job.rb
@@ -5,12 +5,11 @@ module Travis
   module Scheduler
     module Serialize
       class Worker
-        class Job < Struct.new(:job)
+        class Job < Struct.new(:job, :config)
           extend Forwardable
 
-          def_delegators :job, :id, :repository, :source, :config, :commit,
-            :number, :queue, :state, :debug_options, :queued_at, :allow_failure,
-            :stage
+          def_delegators :job, :id, :repository, :source, :commit, :number,
+            :queue, :state, :debug_options, :queued_at, :allow_failure, :stage
           def_delegators :source, :request
 
           def env_vars
@@ -37,12 +36,19 @@ module Travis
           end
 
           def ssh_key
-            config[:source_key]
+            job.config[:source_key]
           end
 
           def decrypted_config
             secure = Travis::SecureConfig.new(repository.key)
-            Config.decrypt(config, secure, full_addons: secure_env?, secure_env: secure_env?)
+            Config.decrypt(job.config, secure, full_addons: secure_env?, secure_env: secure_env?)
+          end
+
+          def vm_config
+            # we'll want to see out what kinds of vm_config sets we have and
+            # then decide how to best map what to where. at this point that
+            # decision is yagni though, so i'm just picking :gpu as a key here.
+            vm_config? && vm_configs[:gpu] ? vm_configs[:gpu].to_h : {}
           end
 
           private
@@ -52,9 +58,17 @@ module Travis
             end
 
             def has_secure_vars?(key)
-              config.key?(key) &&
-              config[key].respond_to?(:key?) &&
-              config[key].key?(:secure)
+              job.config.key?(key) &&
+                job.config[key].respond_to?(:key?) &&
+                job.config[key].key?(:secure)
+            end
+
+            def vm_config?
+              Features.active?(:vm_config, repository) && job.config.dig(:resources, :gpu)
+            end
+
+            def vm_configs
+              config[:vm_configs] || {}
             end
         end
       end

--- a/lib/travis/scheduler/serialize/worker/repo.rb
+++ b/lib/travis/scheduler/serialize/worker/repo.rb
@@ -17,10 +17,6 @@ module Travis
             Features.active?(:premium_vms, repo) ? :premium : :default
           end
 
-          def vm_config
-            vm_configs[slug] || {}
-          end
-
           def timeouts
             { hard_limit: hard_limit_timeout, log_silence: timeout(:log_silence) }
           end
@@ -68,10 +64,6 @@ module Travis
 
             def source_host
               config[:github][:source_host] || 'github.com'
-            end
-
-            def vm_configs
-              config[:vm_configs] || {}
             end
         end
       end

--- a/spec/travis/scheduler/serialize/worker_spec.rb
+++ b/spec/travis/scheduler/serialize/worker_spec.rb
@@ -167,8 +167,22 @@ describe Travis::Scheduler::Serialize::Worker do
   end
 
   describe 'vm_config' do
-    before { config[:vm_configs] = { 'svenfuchs/gem-release' => { bloop: :floop } } }
-    it { expect(data[:vm_config]).to eq(bloop: :floop) }
+    before { config[:vm_configs] = { gpu: { gpu_count: 1 } } }
+
+    describe 'with the feature flag not enabled' do
+      it { expect(data[:vm_config]).to eq({}) }
+    end
+
+    describe 'with the feature flag enabled, but no resources config given' do
+      before { Travis::Features.activate_repository(:vm_config, repo) }
+      it { expect(data[:vm_config]).to eq({}) }
+    end
+
+    describe 'with the feature flag enabled, and resources config given' do
+      before { Travis::Features.activate_repository(:vm_config, repo) }
+      before { job.config[:resources] = { gpu: true } }
+      it { expect(data[:vm_config]).to eq gpu_count: 1 }
+    end
   end
 
   describe 'with debug options' do


### PR DESCRIPTION
this changes behaviour around passing `vm_config` to the worker as follows. 

if users have opted into `resources.gpu: true` and they are allowed to do so as per feature flag, we do:

* unconditionally route jobs to GCE
* pass the `gpu` vm config as `vm_config` to the worker (rather than a repos specific vm config)