### PR TITLE
Refactor Scheduler::Jobs to disregard all except one capacity besides public

### DIFF
--- a/lib/travis/scheduler/jobs/capacity/boost.rb
+++ b/lib/travis/scheduler/jobs/capacity/boost.rb
@@ -5,6 +5,10 @@ module Travis
     module Jobs
       module Capacity
         class Boost < Base
+          def applicable?
+            boost.exists?
+          end
+
           def report(status, job)
             super.merge(max: max)
           end
@@ -16,7 +20,7 @@ module Travis
             end
 
             def boost
-              Model::Boost.new(owners, context.redis)
+              @boost ||= Model::Boost.new(owners, context.redis)
             end
         end
       end

--- a/lib/travis/scheduler/jobs/capacity/config.rb
+++ b/lib/travis/scheduler/jobs/capacity/config.rb
@@ -5,6 +5,10 @@ module Travis
         # what does config mean with regards to paid/free capacity? do we need
         # richer config format? or can we get rid of it on com?
         class Config < Base
+          def applicable?
+            owners.logins.any? { |login| max_for(login) }
+          end
+
           def report(status, job)
             super.merge(max: max)
           end
@@ -12,11 +16,11 @@ module Travis
           private
 
             def max
-              @max ||= owners.logins.map { |login| max_for(login) }.inject(&:+)
+              @max ||= owners.logins.map { |login| max_for(login).to_i }.inject(&:+)
             end
 
             def max_for(login)
-              config[:limit][:by_owner][login.to_sym].to_i
+              config[:limit][:by_owner][login.to_sym]
             end
         end
       end

--- a/lib/travis/scheduler/jobs/capacity/education.rb
+++ b/lib/travis/scheduler/jobs/capacity/education.rb
@@ -7,6 +7,10 @@ module Travis
         class Education < Base
           include Helper::Memoize
 
+          def applicable?
+            educational?
+          end
+
           def accept?(job)
             super if educational?
           end

--- a/lib/travis/scheduler/jobs/capacity/plan.rb
+++ b/lib/travis/scheduler/jobs/capacity/plan.rb
@@ -3,6 +3,10 @@ module Travis
     module Jobs
       module Capacity
         class Plan < Base
+          def applicable?
+            owners.subscribed?
+          end
+
           def report(status, job)
             super.merge(max: max)
           end

--- a/lib/travis/scheduler/jobs/capacity/public.rb
+++ b/lib/travis/scheduler/jobs/capacity/public.rb
@@ -3,6 +3,10 @@ module Travis
     module Jobs
       module Capacity
         class Public < Base
+          def applicable?
+            true
+          end
+
           def reduce(jobs)
             rest = super(jobs.select(&:public?))
             rest + jobs.select(&:private?)

--- a/lib/travis/scheduler/jobs/capacity/trial.rb
+++ b/lib/travis/scheduler/jobs/capacity/trial.rb
@@ -5,6 +5,10 @@ module Travis
     module Jobs
       module Capacity
         class Trial < Base
+          def applicable?
+            trial.active?
+          end
+
           def accept?(job)
             trial.active? && super
           end

--- a/lib/travis/scheduler/model/boost.rb
+++ b/lib/travis/scheduler/model/boost.rb
@@ -8,15 +8,25 @@ module Travis
 
         BOOST = 'scheduler.owner.limit.%s'
 
+        def exists?
+          boosts.any?
+        end
+        memoize :exists?
+
         def max
-          owners.logins.map { |login| boost_for(login) }.inject(&:+)
+          boosts.map(&:to_i).inject(&:+).to_i
         end
         memoize :max
 
         private
 
+          def boosts
+            owners.logins.map { |login| boost_for(login) }.compact
+          end
+          memoize :boosts
+
           def boost_for(login)
-            redis.get(key_for(login)).to_i
+            redis.get(key_for(login))
           end
 
           def key_for(login)


### PR DESCRIPTION
> do the "right thing" for public/free jobs … and for all other capacities (`boost config plan education trial`) pick the first one that is applicable, in this order, and only respect this one, and discard all other ones