### PR TITLE
Protect against missing owner data

### DIFF
--- a/lib/travis/owners.rb
+++ b/lib/travis/owners.rb
@@ -7,6 +7,8 @@ require 'travis/owners/subscriptions'
 
 module Travis
   module Owners
+    ArgumentError = Class.new(::ArgumentError)
+
     class << self
       def group(owner, config, logger = nil)
         owner = find(owner) if owner.is_a?(Hash)
@@ -14,6 +16,7 @@ module Travis
       end
 
       def find(owner)
+        raise ArgumentError, 'Invalid owner data: %p' % owner unless owner[:owner_type]
         Kernel.const_get(owner[:owner_type]).find(owner[:owner_id])
       end
 

--- a/lib/travis/scheduler/service/enqueue_owners.rb
+++ b/lib/travis/scheduler/service/enqueue_owners.rb
@@ -64,6 +64,8 @@ module Travis
 
           def exclusive(&block)
             super(['scheduler.owners', owners.key].join('-'), config.to_h, retries: 0, &block)
+          rescue Owners::ArgumentError => e
+            error e.message
           end
 
           def jid

--- a/lib/travis/scheduler/service/ping.rb
+++ b/lib/travis/scheduler/service/ping.rb
@@ -30,7 +30,8 @@ module Travis
               scope = scope.where('created_at <= ?', Time.now - interval)
               scope = scope.distinct
               scope = scope.select(:owner_type, :owner_id)
-              scope.map { |job| [job.owner_id, job.owner_type] }.uniq
+              scope = scope.map { |job| [job.owner_id, job.owner_type] }.uniq
+              scope - [[0, nil]]
             end
           end
 

--- a/spec/travis/scheduler/service/enqueue_owners_spec.rb
+++ b/spec/travis/scheduler/service/enqueue_owners_spec.rb
@@ -45,5 +45,11 @@ describe Travis::Scheduler::Service::EnqueueOwners do
     it { expect(log).to include "I 1234 enqueueing job #{job.id} (svenfuchs/gem-release)" }
     it { expect(log).to include "I 1234 Publishing worker payload for job=#{job.id} queue=builds.gce" }
   end
+
+  describe 'with invalid owner data' do
+    let(:data) { { owner_type: nil, owner_id: 0 } }
+    before { service.run }
+    it { expect(log).to include 'E Invalid owner data: {:owner_type=>nil, :owner_id=>0}' }
+  end
 end
 


### PR DESCRIPTION
We have early jobs in the db that do not have an owner association. If
these are restarted Scheduler starts raising mysterious exceptions.