### PR TITLE
Add homebrew to the list of safe addons

### DIFF
--- a/lib/travis/scheduler/serialize/worker/config/addons.rb
+++ b/lib/travis/scheduler/serialize/worker/config/addons.rb
@@ -11,6 +11,7 @@ module Travis
               browserstack
               chrome
               firefox
+              homebrew
               hostname
               hosts
               jwt


### PR DESCRIPTION
We want the Homebrew addon to be able to run for all builds including PRs from forks, so it should be on the list of safe addons.

This should fix https://github.com/travis-ci/travis-ci/issues/10149.