### PR TITLE
Prepare "linux_sudo_required" for percentage-based rollout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp
 .env
 NOTES.md
 .envrc
+/db/

--- a/lib/travis/queue/force_linux_sudo_required.rb
+++ b/lib/travis/queue/force_linux_sudo_required.rb
@@ -1,10 +1,56 @@
 module Travis
   class Queue
-    class ForceLinuxSudoRequired < Struct.new(:owner)
+    class ForceLinuxSudoRequired < Struct.new(:repo, :owner)
       def apply?
-        Travis::Features.enabled_for_all?(:linux_sudo_required) ||
-          Travis::Features.owner_active?(:linux_sudo_required, owner)
+        return true if Travis::Features.enabled_for_all?(:linux_sudo_required) ||
+                       Travis::Features.active?(:linux_sudo_required, repo) ||
+                       Travis::Features.owner_active?(:linux_sudo_required, owner)
+        decision = decide_force_linux_sudo_required
+        if decision[:chosen?]
+          Travis::Scheduler.logger.info(
+            "selected sudo: required why=#{decision[:reason]} slug=#{repo.slug}"
+          )
+          Travis::Features.activate_repository(:linux_sudo_required, repo)
+        end
+        Travis::Features.active?(:linux_sudo_required, repo)
       end
+
+      private
+
+        def decide_force_linux_sudo_required
+          return { chosen?: true, reason: :first_job } if first_job?
+          {
+            chosen?: rand <= rollout_force_linux_sudo_required_percentage,
+            reason: :random
+          }
+        end
+
+        def rollout_force_linux_sudo_required_percentage
+          Float(
+            Travis::Scheduler.config.rollout.force_linux_sudo_required_percentage
+          )
+        end
+
+        def first_job?
+          return @first_job if defined?(@first_job)
+          @first_job = begin
+            first_job_id.nil?
+          rescue => e
+            Travis::Scheduler.logger.warn(
+              "failed to fetch first job for repository=#{repo.slug}"
+            )
+            false
+          end
+        end
+
+        def first_job_id
+          Job.where(
+            owner_id: repo.owner.id,
+            owner_type: repo.owner.class.name,
+            state: 'passed',
+            repository_id: repo.id
+          ).select(:id).limit(1).first
+        end
     end
   end
 end

--- a/lib/travis/queue/sudo.rb
+++ b/lib/travis/queue/sudo.rb
@@ -40,7 +40,7 @@ module Travis
         end
 
         def force_linux_sudo_required?
-          ForceLinuxSudoRequired.new(repo.owner).apply?
+          ForceLinuxSudoRequired.new(repo, repo.owner).apply?
         end
 
         def force_precise_sudo_required?

--- a/lib/travis/scheduler/config.rb
+++ b/lib/travis/scheduler/config.rb
@@ -26,7 +26,7 @@ module Travis
              site:       ENV['TRAVIS_SITE'] || 'org',
              ssl:        { },
              job_board:  { url: ENV['JOB_BOARD_URL'] || 'https://job-board.travis-ci.org', auth: ENV['JOB_BOARD_AUTH'] || 'user:pass' },
-             rollout:    { force_precise_sudo_required_percentage: 0.05 }
+             rollout:    { force_precise_sudo_required_percentage: 0.05, force_linux_sudo_required_percentage: 0.05 }
 
       def metrics
         # TODO fix keychain?

--- a/spec/travis/queue/force_linux_sudo_required_spec.rb
+++ b/spec/travis/queue/force_linux_sudo_required_spec.rb
@@ -1,10 +1,11 @@
 describe Travis::Queue::ForceLinuxSudoRequired do
   let(:config) { {} }
   let(:owner) { FactoryGirl.build(:user, login: 'cabbagen') }
+  let(:repo) { FactoryGirl.build(:repo, owner: owner) }
   let(:enabled_for_all?) { false }
   let(:active?) { false }
 
-  subject { described_class.new(owner) }
+  subject { described_class.new(repo, owner) }
 
   before do
     Travis::Features


### PR DESCRIPTION
and change the feature checking to look at both owner and repo.

The way this is _supposed_ to work, based on how the similar code for setting `sudo: required` when `dist: precise` is for first-job repos and a random percentage of already-activated repos to be considered for having the feature _activated_.  Once activated, the repo will remain activated unless a Travis support human with access to admin tooling de-activates the feature.