### PR TITLE
Match command names exactly

### DIFF
--- a/lib/travis/queue/sudo_detector.rb
+++ b/lib/travis/queue/sudo_detector.rb
@@ -7,8 +7,6 @@ module Travis
         sudo
       )
 
-      PATTERN = /^[^#]*\b(#{EXECUTABLES.join('|')})\b/
-
       STAGES = %i(
         before_install
         install
@@ -22,13 +20,28 @@ module Travis
       )
 
       def detect?
-        stages.any? { |script| PATTERN =~ script.to_s }
+        stages.any? do |script|
+          commands = script.to_s.sub(/#.*$/,'')
+          has_common? commands.split, EXECUTABLES
+        end
       end
 
       private
 
         def stages
           config.values_at(*STAGES).compact.flatten
+        end
+
+        def has_common?(a,b)
+          intersection = []
+          Array(a).each do |a_el|
+            Array(b).each do |b_el|
+              if a_el == b_el
+                intersection << a_el
+              end
+            end
+          end
+          ! intersection.empty?
         end
     end
   end

--- a/spec/travis/queue/sudo_detector_spec.rb
+++ b/spec/travis/queue/sudo_detector_spec.rb
@@ -9,6 +9,7 @@ describe Travis::Queue::SudoDetector do
       [{ before_install: ['docker run busybox echo whatever'] }, true],
       [{ before_script: ['echo ; echo ; echo ; sudo echo ; echo'] }, true],
       [{ install: '# no sudo needed here' }, false],
+      [{ script: 'docker-compose up' }, false],
       [{ install: true }, false],
     ]
 


### PR DESCRIPTION
Instead of using a Regexp to look for suspicious strings, we match the 
commands
by word, so that commands such as `docker-compose`
does not trip the wire.