### PR TITLE
warmer: control rollout via feature flag

### DIFF
--- a/lib/travis/scheduler/serialize/worker.rb
+++ b/lib/travis/scheduler/serialize/worker.rb
@@ -28,7 +28,8 @@ module Travis
             enterprise: !!config[:enterprise],
             prefer_https: !!config[:prefer_https]
           }
-          data[:trace] = true if job.trace?
+          data[:trace]  = true if job.trace?
+          data[:warmer] = true if job.warmer?
           data[:oauth_token] = github_oauth_token if config[:prefer_https]
           data
         end

--- a/lib/travis/scheduler/serialize/worker/job.rb
+++ b/lib/travis/scheduler/serialize/worker/job.rb
@@ -56,6 +56,10 @@ module Travis
             Rollout.matches?(:trace, uid: repository.owner.uid, owner: repository.owner.login, repo: repository.slug, redis: Scheduler.redis)
           end
 
+          def warmer?
+            Rollout.matches?(:warmer, uid: repository.owner.uid, owner: repository.owner.login, repo: repository.slug, redis: Scheduler.redis)
+          end
+
           private
 
             def env_var(var)


### PR DESCRIPTION
This allows us to have more control over the rollout progression of [warmer](https://github.com/travis-ci/warmer). We can enable it for a percentage of owners. Worker will check the `warmer` flag in the payload.

Code based on https://github.com/travis-ci/travis-scheduler/pull/165.

refs travis-ci/reliability#195