### PR TITLE
apply trace and warmer feature flags to random sample of jobs

### DIFF
--- a/lib/travis/scheduler/serialize/worker/job.rb
+++ b/lib/travis/scheduler/serialize/worker/job.rb
@@ -52,12 +52,11 @@ module Travis
           end
 
           def trace?
-            return true if job.config[:trace]
-            Rollout.matches?(:trace, uid: repository.owner.uid, owner: repository.owner.login, repo: repository.slug, redis: Scheduler.redis)
+            Rollout.matches?(:trace, uid: SecureRandom.hex, owner: repository.owner.login, repo: repository.slug, redis: Scheduler.redis)
           end
 
           def warmer?
-            Rollout.matches?(:warmer, uid: repository.owner.uid, owner: repository.owner.login, repo: repository.slug, redis: Scheduler.redis)
+            Rollout.matches?(:warmer, uid: SecureRandom.hex, owner: repository.owner.login, repo: repository.slug, redis: Scheduler.redis)
           end
 
           private


### PR DESCRIPTION
This way we get a sample of all jobs and not the same jobs from the same owners. This also improves fault tolerance. If tracing causes an issue, users are at least able to restart the job without triggering the problem repeatedly.

This also removes the ability to set `trace: true` in `.travis.yml`. It's safer to manage that via rollout.

vaguely refs https://github.com/travis-ci/reliability/issues/195