### PR TITLE
Bump rack version to  pick up security patches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'sentry-raven'
 gem 'rollout'
 gem 'redlock'
 gem 'multi_json',         '~> 1.11'
-gem 'rack', '1.6.4'
+gem 'rack',               '>= 1.6.11'
 
 gem 'libhoney'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (2.0.5)
-    rack (1.6.4)
+    rack (2.0.6)
     rack-protection (2.0.1)
       rack
     rake (11.3.0)
@@ -230,7 +230,7 @@ DEPENDENCIES
   multi_json (~> 1.11)
   pg
   pry
-  rack (= 1.6.4)
+  rack (>= 1.6.11)
   rake
   redis-namespace
   redlock


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-16471