### PR TITLE
Apply build stages limit first

### DIFF
--- a/lib/travis/scheduler/jobs/limits.rb
+++ b/lib/travis/scheduler/jobs/limits.rb
@@ -10,7 +10,9 @@ module Travis
       class Limits < Struct.new(:context, :owners, :state)
         include Helper::Memoize
 
-        NAMES = %w(repo queue stages)
+        # These are ordered by how specific the limit is, from most specific to least.
+        # In other orders, we may apply a stricter limit than is intended.
+        NAMES = %w(stages repo queue)
 
         def accept(job)
           yield job if accept?(job)


### PR DESCRIPTION
This prevents the case where we filter out a bunch of jobs by repo or by queue, then go and reject some of the jobs we did select by build stage, leaving several jobs unconsidered.