### PR TITLE
Don't count migrated jobs towards concurrency and don't enqueue them

### DIFF
--- a/lib/travis/scheduler/limit/jobs.rb
+++ b/lib/travis/scheduler/limit/jobs.rb
@@ -1,5 +1,6 @@
 require 'travis/scheduler/helper/context'
 require 'travis/scheduler/helper/metrics'
+require 'travis/support/filter_migrated_jobs'
 
 module Travis
   module Scheduler
@@ -20,6 +21,7 @@ module Travis
         require 'travis/scheduler/limit/state'
 
         include Helper::Context, Helper::Metrics
+        include FilterMigratedJobs
 
         LIMITS = [ByOwner, ByRepo, ByQueue, ByStage]
         attr_reader :waiting_by_owner
@@ -125,7 +127,9 @@ module Travis
           end
 
           def queueable
-            @queueable ||= Job.by_owners(owners.all).queueable.to_a
+            @queueable ||= begin
+              filter_migrated_jobs(Job.by_owners(owners.all).queueable.to_a)
+            end
           end
           time :queueable, key: 'scheduler.queueable_jobs'
 

--- a/lib/travis/scheduler/limit/state.rb
+++ b/lib/travis/scheduler/limit/state.rb
@@ -1,8 +1,11 @@
+require 'travis/support/filter_migrated_jobs'
+
 module Travis
   module Scheduler
     module Limit
       class State
         BOOST = 'scheduler.owner.limit.%s'
+        include FilterMigratedJobs
 
         attr_reader :owners, :config
 
@@ -14,19 +17,19 @@ module Travis
         end
 
         def running_by_owners
-          @count[:owners] ||= running_jobs_by_owners.count
+          @count[:owners] ||= filter_running_jobs(running_jobs_by_owners).count
         end
 
         def running_by_owners_public
-          @count[:public] ||= running_jobs_by_owners.where(private: false).count
+          @count[:public] ||= filter_running_jobs(running_jobs_by_owners.where(private: false)).count
         end
 
         def running_by_repo(id)
-          @count[:repo][id] ||= Job.by_repo(id).running.count
+          @count[:repo][id] ||= filter_running_jobs(Job.by_repo(id).running).count
         end
 
         def running_by_queue(queue)
-          @count[:queue][queue] ||= Job.by_owners(owners.all).by_queue(queue).running.count
+          @count[:queue][queue] ||= filter_running_jobs(Job.by_owners(owners.all).by_queue(queue).running).count
         end
 
         def boost_for(login)
@@ -37,6 +40,10 @@ module Travis
 
           def running_jobs_by_owners
             @running_jobs_by_owners ||= Job.by_owners(owners.all).running
+          end
+
+          def filter_running_jobs(jobs)
+            filter_migrated_jobs(jobs)
           end
       end
     end

--- a/lib/travis/support/filter_migrated_jobs.rb
+++ b/lib/travis/support/filter_migrated_jobs.rb
@@ -1,0 +1,11 @@
+module Travis::FilterMigratedJobs
+  def filter_migrated_jobs(jobs)
+    if Travis.config.com?
+      jobs.find_all { |job|
+        !job.org_id || (job.restarted_at && job.restarted_at > job.repository.migrated_at)
+      }
+    else
+      jobs
+    end
+  end
+end


### PR DESCRIPTION
I've already attempted it to fix the problem in 01139a4, but I only
fixed one code path, which is currently not used, so the changes didn't
go into effect. This commit applies the changes to the other code path
as well.

The reason we need to do it is because when we migrate jobs from .org to
.com they might still be in a state that is considered by gatekeeper. So
they might be started but they're running on .org not .com, thus we
shouldn't count them as running on .com. The same with new jobs - we
don't want to start them as they would start on .org anyway.

I decided to filter these jobs in code instead of in the database
because the number of jobs that we fetch from the database is relatively
small and if I had to do it in the DB I would have to always join jobs
with repositories, which actually might be slower.