### PR TITLE
allow env vars to be hashes

### DIFF
--- a/lib/travis/scheduler/serialize/worker/config/decrypt.rb
+++ b/lib/travis/scheduler/serialize/worker/config/decrypt.rb
@@ -20,7 +20,7 @@ module Travis
               end
 
               def process_env(env)
-                env = secure_env? ? decrypt_env(env) : remove_encrypted_env(env)
+                env = secure_env? ? decrypt_env(env) : to_vars(remove_encrypted_env(env))
                 env.compact
               end
 
@@ -30,8 +30,24 @@ module Travis
                 end
               end
 
-              def decrypt_env(env)
-                env.map { |var| decrypt_var(var) }
+              def decrypt_env(vars)
+                case vars
+                when Array
+                  vars.map { |var| decrypt_env(var) }.flatten
+                when Hash
+                  vars.key?(:secure) ? decrypt_var(vars) : decrypt_hash(vars)
+                when String
+                  decrypt_var(vars)
+                end
+              end
+
+              def decrypt_hash(vars)
+                vars.map do |key, value|
+                  secure = false
+                  value = decryptor.decrypt(value) { |value| secure = value }
+                  var = "#{key}=#{value}"
+                  secure ? "SECURE #{var}" : var
+                end
               end
 
               def decrypt_var(var)
@@ -40,6 +56,17 @@ module Travis
                 end
               rescue
                 {}
+              end
+
+              def to_vars(env)
+                case env
+                when Array
+                  env.map { |var| to_vars(var) }.flatten
+                when Hash
+                  env.map { |key, value| [key, value].join('=') }
+                when String
+                  env
+                end
               end
           end
         end

--- a/lib/travis/scheduler/serialize/worker/config/normalize.rb
+++ b/lib/travis/scheduler/serialize/worker/config/normalize.rb
@@ -61,13 +61,7 @@ module Travis
               end
 
               def normalize_env(env)
-                [env].flatten.compact.map do |line|
-                  if line.is_a?(Hash) && !line.key?(:secure)
-                    line.map { |k, v| "#{k}=#{v}" }.join(' ')
-                  else
-                    line
-                  end
-                end
+                [env].flatten.compact
               end
 
               def normalize_deploy

--- a/spec/travis/scheduler/serialize/worker/config_spec.rb
+++ b/spec/travis/scheduler/serialize/worker/config_spec.rb
@@ -12,8 +12,9 @@ describe Travis::Scheduler::Serialize::Worker::Config do
       let(:config) { { env: env, global_env: env } }
       let(:env)    { [{ secure: 'invalid' }] }
 
+      before { subject }
+
       it do
-        subject
         expect(config).to eql(
           env:        [{ secure: 'invalid' }],
           global_env: [{ secure: 'invalid' }]
@@ -21,12 +22,14 @@ describe Travis::Scheduler::Serialize::Worker::Config do
       end
     end
 
-    describe 'regular vars remain untouched' do
+    describe 'string vars' do
       let(:config) { { rvm: '1.8.7', env: 'FOO=foo', global_env: 'BAR=bar' } }
+      it { should eql(rvm: '1.8.7', env: ['FOO=foo'], global_env: ['BAR=bar']) }
+    end
 
-      it do
-        should eql(rvm: '1.8.7', env: ['FOO=foo'], global_env: ['BAR=bar'])
-      end
+    describe 'hash vars' do
+      let(:config) { { rvm: '1.8.7', env: { FOO: 'foo' }, global_env: { BAR: 'bar' } } }
+      it { should eql(rvm: '1.8.7', env: ['FOO=foo'], global_env: ['BAR=bar']) }
     end
 
     describe 'with a nil env' do
@@ -45,40 +48,28 @@ describe Travis::Scheduler::Serialize::Worker::Config do
 
     include_examples :common
 
-    describe 'decrypts env vars' do
+    describe 'decrypts env string vars' do
       let(:config) { { env: env, global_env: env } }
       let(:env)    { [encrypt('FOO=foo')] }
+      it { should eql env: ['SECURE FOO=foo'], global_env: ['SECURE FOO=foo'] }
+    end
 
-      it do
-        should eql(
-          env:        ['SECURE FOO=foo'],
-          global_env: ['SECURE FOO=foo']
-        )
-      end
+    describe 'decrypts env hash vars' do
+      let(:config) { { env: env, global_env: env } }
+      let(:env)    { [FOO: encrypt('foo')] }
+      it { should eql env: ['SECURE FOO=foo'], global_env: ['SECURE FOO=foo'] }
     end
 
     describe 'can mix secure and normal env vars' do
       let(:config) { { env: env, global_env: env } }
       let(:env)    { [encrypt('FOO=foo'), 'BAR=bar'] }
-
-      it do
-        should eql(
-          env:        ['SECURE FOO=foo', 'BAR=bar'],
-          global_env: ['SECURE FOO=foo', 'BAR=bar']
-        )
-      end
+      it { should eql env: ['SECURE FOO=foo', 'BAR=bar'], global_env: ['SECURE FOO=foo', 'BAR=bar'] }
     end
 
     describe 'normalizes env vars which are hashes to strings' do
       let(:config) { { env: env, global_env: env } }
       let(:env)    { [{ FOO: 'foo', BAR: 'bar' }, encrypt('BAZ=baz')] }
-
-      it do
-        should eql(
-          env:        ["FOO=foo BAR=bar", "SECURE BAZ=baz"],
-          global_env: ["FOO=foo BAR=bar", "SECURE BAZ=baz"]
-        )
-      end
+      it { should eql env: ['FOO=foo', 'BAR=bar', 'SECURE BAZ=baz'], global_env: ['FOO=foo', 'BAR=bar', 'SECURE BAZ=baz'] }
     end
   end
 
@@ -90,14 +81,7 @@ describe Travis::Scheduler::Serialize::Worker::Config do
     describe 'removes secure env vars' do
       let(:config) { { rvm: '1.8.7', env: env, global_env: env } }
       let(:env)    { ['FOO=foo', 'BAR=bar', encrypt('BAZ=baz')] }
-
-      it do
-        should eql(
-          rvm:        '1.8.7',
-          env:        ["FOO=foo", 'BAR=bar'],
-          global_env: ["FOO=foo", 'BAR=bar']
-        )
-      end
+      it { should eql rvm: '1.8.7', env: ["FOO=foo", 'BAR=bar'], global_env: ["FOO=foo", 'BAR=bar'] }
     end
   end
 
@@ -202,5 +186,4 @@ describe Travis::Scheduler::Serialize::Worker::Config do
       end
     end
   end
-
 end


### PR DESCRIPTION
the changes in the spec are formatting only, except for

```ruby
it { should eql env: ['FOO=foo', 'BAR=bar', 'SECURE BAZ=baz'], global_env: ['FOO=foo', 'BAR=bar', 'SECURE BAZ=baz'] }
```

which used to be

```ruby
it { should eql env: ['FOO=foo BAR=bar', 'SECURE BAZ=baz'], global_env: ['FOO=foo BAR=bar', 'SECURE BAZ=baz'] }
```

which should be alright.