### PR TITLE
more useful message when decryption failed

### DIFF
--- a/lib/travis/support/secure_config.rb
+++ b/lib/travis/support/secure_config.rb
@@ -61,8 +61,7 @@ module Travis
           Travis.logger.error("Can not decrypt secure config value: #{value.inspect[0..10]} using key: #{key.inspect[0..10]}")
         end
       rescue OpenSSL::PKey::RSAError => e
-        # Travis.logger.error("Error during decrypting secure config value: #{e.message}")
-        value
+        '[unable to decrypt]'
       end
 
       def secure_key?(key)


### PR DESCRIPTION
before: 

![image](https://user-images.githubusercontent.com/2208/68417595-faa41180-0196-11ea-967b-de4e0b68597a.png)

after:

![image](https://user-images.githubusercontent.com/2208/68417627-0a235a80-0197-11ea-84c2-c3d93543809f.png)

(we might also change travis-build to actually output a message to the log if one of the env vars is `[unable to decrypt]`)