### PR TITLE
Separating queues 3.1

### DIFF
--- a/lib/travis/queue/matcher.rb
+++ b/lib/travis/queue/matcher.rb
@@ -16,7 +16,7 @@ module Travis
         matches.any? && matches.all? do |key, value|
           attr_val = attrs[key]
           if attr_val.is_a?(Array)
-            attr_val.include?(value)
+            (attr_val & [value].flatten).any?
           else
             value === attr_val
           end
@@ -70,7 +70,7 @@ module Travis
         end
 
         def services
-          ->(services) { (Array(job.config[:services]) & services).any? }
+          job.config[:services]
         end
 
         def repo

--- a/lib/travis/queue/matcher.rb
+++ b/lib/travis/queue/matcher.rb
@@ -2,7 +2,7 @@ module Travis
   class Queue
     class Matcher < Struct.new(:job, :config, :logger)
       KEYS = %i(slug owner os language sudo dist group osx_image percentage
-        resources services arch virt)
+        resources services arch virt paid)
 
       MSGS = {
         unknown_matchers: 'unknown matchers used for queue %s: %s (repo=%s)"'
@@ -13,13 +13,24 @@ module Travis
       def matches?(attrs)
         check_unknown_matchers(attrs.keys)
         matches = matches_for(attrs)
-        matches.any? && matches.all? { |key, value| value === attrs[key] }
+        matches.any? && matches.all? do |key, value|
+          attr_val = attrs[key]
+          if attr_val.is_a?(Array)
+            attr_val.include?(value)
+          else
+            value === attr_val
+          end
+        end
       end
 
       private
 
         def matches_for(attrs)
           (KEYS & attrs.keys).map { |key| [key, send(key)] }.to_h
+        end
+
+        def paid
+          job.paid?
         end
 
         def slug

--- a/lib/travis/scheduler/record/job.rb
+++ b/lib/travis/scheduler/record/job.rb
@@ -70,6 +70,10 @@ class Job < ActiveRecord::Base
   serialize :config
   serialize :debug_options
 
+  def paid?
+    owner&.paid? || false # prevents nil
+  end
+
   def finished?
     FINISHED_STATES.include?(state.try(:to_sym))
   end


### PR DESCRIPTION
This PR introduced 2 changes:
1. Allows to use `paid` flag in queue config. The flag is taken into account only if it exists in a config for certain queue.
2. Handles arrays for all fields.