### PR TITLE
Pull db-setup.yml from `master` branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 import:
-  - travis-ci/build-configs:db-setup.yml@sb-remove-user-travis
+  - travis-ci/build-configs:db-setup.yml
 
 rvm: 2.6.5
 


### PR DESCRIPTION
The workaround is no longer necessary after https://github.com/travis-ci/build-configs/pull/4