### PR TITLE
[BV2-168] Fix stuck jobs due to billing

### DIFF
--- a/lib/travis/scheduler/jobs/capacity/plan.rb
+++ b/lib/travis/scheduler/jobs/capacity/plan.rb
@@ -12,13 +12,27 @@ module Travis
           end
 
           def accept?(job)
-            super if !on_metered_plan? || billing_allowance[allowance_key(job)]
+            super if !on_metered_plan? || billing_allowed?(job)
           end
 
           private
 
             def max
               @max ||= on_metered_plan? ? billing_allowance['concurrency_limit'] : owners.paid_capacity
+            end
+
+            def billing_allowed?(job)
+              puts billing_allowance[allowance_key(job)]
+              return true if billing_allowance[allowance_key(job)]
+
+              # Cancel job if it has not been queued for more than a day due to
+              # billing allowance
+              if job.created_at < (Time.now - 1.day)
+                payload = { id: job.id, source: 'scheduler' }
+                Hub.push('job:cancel', payload)
+              end
+
+              false
             end
 
             def allowance_key(job)


### PR DESCRIPTION
Cancel jobs that have been not queued for more than a day due to billing allowance.
billing-v2 terminator is not cancelling these jobs, as they have not been queued yet, which leaves them in "stuck" state.