### PR TITLE
Not all jobs have stages

### DIFF
--- a/lib/travis/scheduler/service/set_queue.rb
+++ b/lib/travis/scheduler/service/set_queue.rb
@@ -20,7 +20,7 @@ module Travis
         private
 
           def queue
-            if job.stage.state == "canceled"
+            if job.stage.present? && job.stage.state == "canceled"
               info MSGS[:canceled] % [job.source.id, job.id]
               payload = { id: job.id, source: 'scheduler' }
               Hub.push('job:cancel', payload)

--- a/spec/travis/scheduler/service/event_spec.rb
+++ b/spec/travis/scheduler/service/event_spec.rb
@@ -46,5 +46,13 @@ describe Travis::Scheduler::Service::Event do
       it { expect(Job.first.stage.state).to eq 'canceled' }
       it { expect(log).to include "Build #{build.id} has been canceled, job #{job.id} being canceled" }
     end
+
+    describe 'jobs are queued if there are no stages' do
+      let(:job) { FactoryGirl.create(:job, private: true, state: :created, config: config.to_h, stage_id: nil) }
+      before { service.run }
+      it { expect(Job.first.state).to eq 'queued' }
+      it { expect(log).to include 'Evaluating jobs for owner group: user svenfuchs, org travis-ci' }
+      it { expect(log).to include "enqueueing job #{Job.first.id} (svenfuchs/gem-release)" }
+    end
   end
 end


### PR DESCRIPTION
When stoping jobs of a cancelled build from being queued we need to consider not all jobs have stages.