### PR TITLE
Restrict ruby gem-update version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
 before_install:
   - gem uninstall -v '>=2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '2.3.7'
+  - gem install rubygems-update -v 3.4.22
 
 addons:
   - apt:


### PR DESCRIPTION
Restrict ruby gem-update to 3.4.22 because it still supports ruby 2.6